### PR TITLE
Add missing .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Dotenv
+#
+# This file commits safe environment variables for the development environment.
+# For managing sensitive values and overrides use `/.env.development.local`
+#
+# Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+
+# Rollbar for application monitoring
+ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
+ROLLBAR_ENV=development
+
+DATABASE_URL=postgres://postgres@localhost:5432/dfsseta-apply-for-landing-development
+
+# TODO: Replace `example.com` with the canonical hostname of the app
+CANONICAL_HOSTNAME=example.com
+
+# TODO: Add a comma seperated list of any other hostnames you want to
+# app to respond to and redirect to the canonical hostname, or delete
+# this line completely
+ADDITIONAL_HOSTNAMES=

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,8 @@
+# Dotenv
+#
+# This file commits safe environment variables for the test environment.
+# For managing sensitive values and overrides use `/.env.test.local`
+#
+# Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+
+DATABASE_URL=postgres://postgres@localhost:5432/dfsseta-apply-for-landing-test


### PR DESCRIPTION
We are generally "ignoring" .env files as these usually contain secrets -- but there are two which we need to provide:

- `.env.example`: a template for developers to rename, modify
and use locally
- `.env.test`: for automated tests