### PR TITLE
[31] Stage 1: pilot chooses destination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "jsbundling-rails"
 gem "cssbundling-rails"
+gem "govuk_design_system_formbuilder"
 gem "uglifier", ">= 1.3.0"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,14 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    govuk_design_system_formbuilder (3.3.0)
+      actionview (>= 6.1)
+      activemodel (>= 6.1)
+      activesupport (>= 6.1)
+      html-attributes-utils (~> 0.9, >= 0.9.2)
     high_voltage (3.1.2)
+    html-attributes-utils (0.9.2)
+      activesupport (>= 6.1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -361,6 +368,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  govuk_design_system_formbuilder
   high_voltage
   jbuilder (~> 2.11)
   jquery-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   def health_check
     render json: {
       rails: "OK",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,15 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+  LANDABLE_BODIES = [
+    OpenStruct.new(id: "f869e63d-3ce5-4480-b8ac-3eb0c266f659", name: "Mars"),
+    OpenStruct.new(id: "56f498b9-3b76-4ce8-9f3e-8a9ef20594f3", name: "Saturn (core)"),
+    OpenStruct.new(id: "11bced89-eb9c-4163-ad9e-c3cb89d6745c", name: "International Space Station (ESA)"),
+    OpenStruct.new(id: "bd41bc58-044b-4841-b159-219b091f68f2", name: "Tiangong space station"),
+    OpenStruct.new(id: "5db88724-cb68-431f-a7c6-6f08347458f4", name: "Earth's moon"),
+    OpenStruct.new(id: "21c97e41-ca50-4549-9892-36196d602a0f", name: "Pluto")
+  ].freeze
+
   def health_check
     render json: {
       rails: "OK",

--- a/app/controllers/pilots_controller.rb
+++ b/app/controllers/pilots_controller.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class PilotsController < ApplicationController
+  def start
+    @landable_bodies = LANDABLE_BODIES
+  end
 end

--- a/app/controllers/stages/dates_stage_controller.rb
+++ b/app/controllers/stages/dates_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::DatesStageController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/stages/destination_stage_controller.rb
+++ b/app/controllers/stages/destination_stage_controller.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 class Stages::DestinationStageController < ApplicationController
+  before_action :landable_bodies
+
   def show
+    @destination = DestinationForm.new(destination_id: "")
+  end
+
+  def update
+    @destination = DestinationForm.new(destination_id: params[:destination_form][:destination_id])
+    if @destination.valid?
+      redirect_to(stages_dates_path)
+    else
+      render :show
+    end
+  end
+
+  def landable_bodies
+    @landable_bodies = LANDABLE_BODIES
   end
 end

--- a/app/controllers/stages/destination_stage_controller.rb
+++ b/app/controllers/stages/destination_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::DestinationStageController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class StagesController < ApplicationController
-  def show
-  end
-end

--- a/app/forms/destination_form.rb
+++ b/app/forms/destination_form.rb
@@ -1,0 +1,11 @@
+class DestinationForm
+  include ActiveModel::Model
+
+  attr_accessor :destination_id
+
+  def initialize(destination_id:)
+    @destination_id = destination_id
+  end
+
+  validates :destination_id, presence: {message: "You must choose a destination"}
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <a href="#" class="govuk-header__link govuk-header__service-name">
+          <a href="/" class="govuk-header__link govuk-header__service-name">
             Apply for landing
           </a>
         </div>

--- a/app/views/pilots/start.html.erb
+++ b/app/views/pilots/start.html.erb
@@ -14,12 +14,11 @@
               You can use this service to obtain a landing permit for:
             </p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>Mars</li>
-              <li>Saturn (core)</li>
-              <li>International Space Station (ESA)</li>
-              <li>Tiangong space station</li>
-              <li>Earth's moon</li>
-              <li>Pluto</li>
+              <% @landable_bodies.each do |body| -%>
+                <li>
+                  <%= body.name %>
+                </li>
+              <% end -%>
             </ul>
           </article>
         </row>

--- a/app/views/pilots/start.html.erb
+++ b/app/views/pilots/start.html.erb
@@ -53,7 +53,7 @@
         <div class="row">
           <article class="col">
 
-            <a href="/stages/1-destination" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+            <a href=<%= stages_destination_path %> role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
               Start now
               <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
                 <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/stages/dates_stage/show.html.erb
+++ b/app/views/stages/dates_stage/show.html.erb
@@ -1,0 +1,10 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <div class="row">
+      <article class="col">
+        <h1 class="govuk-heading-xl">Your dates</h1>
+
+      </article>
+    </row>
+  </section>
+</main>

--- a/app/views/stages/destination_stage/show.html.erb
+++ b/app/views/stages/destination_stage/show.html.erb
@@ -6,6 +6,11 @@
         <p class="govuk-body-l">
           Tell us which landable body you are planning to visit
         </p>
+
+        <%= form_for :destination, method: :put, url: stages_destination_path do |f| -%>
+          <%= f.govuk_submit "Save and continue"%>
+        <% end -%>
+
       </article>
     </row>
   </section>

--- a/app/views/stages/destination_stage/show.html.erb
+++ b/app/views/stages/destination_stage/show.html.erb
@@ -3,11 +3,20 @@
     <div class="row">
       <article class="col">
         <h1 class="govuk-heading-xl">Your destination</h1>
-        <p class="govuk-body-l">
-          Tell us which landable body you are planning to visit
-        </p>
 
-        <%= form_for :destination, method: :put, url: stages_destination_path do |f| -%>
+        <%= form_for @destination, method: :put, url: stages_destination_path do |f| -%>
+
+          <%= f.govuk_error_summary %>
+
+          <%= f.govuk_collection_radio_buttons :destination_id,
+            @landable_bodies,
+            :id,
+            :name,
+            legend: { text: "Which landable body are you planning to visit?" },
+            hint: { text: "This service is not able to issue permits to destinations not listed here" },
+            classes: ["destinations"]
+          %>
+
           <%= f.govuk_submit "Save and continue"%>
         <% end -%>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,16 @@ Rails.application.routes.draw do
   get "health_check" => "application#health_check"
   root to: "pilots#start"
 
-  resources :stages, only: :show
+  namespace :stages do
+    get :destination, to: "destination_stage#show"
+    put :destination, to: "destination_stage#update"
+
+    get :dates, to: "dates_stage#show"
+    put :dates, to: "dates_stage#update"
+
+    get :registration_number, to: "registration_number_stage#show"
+    put :registration_number, to: "registration_number_stage#update"
+  end
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present

--- a/spec/features/pilot/stage_0_start_page_understand_service_spec.rb
+++ b/spec/features/pilot/stage_0_start_page_understand_service_spec.rb
@@ -94,6 +94,6 @@ RSpec.feature "Stage 0: Start page - Pilot understands service before engaging" 
 
   def should_see_destination_question_stage
     expect(page).to have_content("destination")
-    expect(page).to have_content("Tell us which landable body you are planning to visit")
+    expect(page).to have_content("Which landable body are you planning to visit?")
   end
 end

--- a/spec/features/pilot/stage_1_choose_destination_spec.rb
+++ b/spec/features/pilot/stage_1_choose_destination_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Feature: Stage 1: Choose destination
+#   So that the service knows which landable body this application concerns
+#   As a pilot making an application
+#   I want to choose the destination of my trip
+
+RSpec.feature "Stage 1: Choose destination" do
+  # Scenario: Must choose a destination
+  #   Given I am at the 'choose destination' stage
+  #   When I fail to make a choice
+  #   And I proceed to the next stage
+  #   Then I should see that a destination must be chosen
+  #
+  #   When I choose a destination
+  #   And I proceed to the next stage
+  #   Then I should find myself at the 'provide dates' stage
+
+  scenario "Stage 1: Choose destination" do
+    given_i_am_at_the_choose_destination_stage
+    when_i_fail_to_make_a_choice
+    and_i_proceed_to_the_next_stage
+    then_i_should_see_that_a_destination_must_be_chosen
+
+    when_choose_a_destination
+    and_i_proceed_to_the_next_stage
+    then_i_should_find_myself_at_the_provide_dates_stage
+  end
+
+  # helpers
+
+  def given_i_am_at_the_choose_destination_stage
+    visit("stages/destination")
+  end
+
+  def when_i_fail_to_make_a_choice
+    # noop
+  end
+
+  def and_i_proceed_to_the_next_stage
+    click_button("Save and continue")
+  end
+
+  def then_i_should_see_that_a_destination_must_be_chosen
+    expect(page).to have_content("You must choose a destination")
+  end
+
+  def when_choose_a_destination
+    within(".destinations") do
+      choose("Saturn (core)")
+    end
+  end
+
+  def then_i_should_find_myself_at_the_provide_dates_stage
+    expect(current_path).to eq("/stages/dates")
+    expect(page).to have_content("Your dates")
+  end
+end

--- a/spec/forms/destination_form_spec.rb
+++ b/spec/forms/destination_form_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe DestinationForm do
+  describe "it validates presence of destination" do
+    context "when destination is blank" do
+      let(:form) { DestinationForm.new(destination_id: "") }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:destination_id)
+          expect(form.errors.full_messages.join).to match("You must choose a destination")
+        end
+      end
+    end
+
+    context "when destination is present" do
+      let(:form) { DestinationForm.new(destination_id: "abc123") }
+
+      it "should not flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:destination_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello ticket 31](https://trello.com/c/LpHfsIFq/31-stage-2-pilot-chooses-destination)

In this PR we:

- propose a pattern for controllers/views for the several stages of the multi-stage questionnaire
- introduce the use of "form objects" to manage validation of each stage independently of any core domain entities which might be handled with the ActiveRecord "model" pattern (e.g. the submission of a final application for a permit)
- implement the first stage of the multi-stage questionnaire: "Pilot chooses destination from list of available landable bodies"

We also:

- introduce the GOV.UK Design System Formbuilder gem from DfE Digital to provide Rails helpers for form elements and error handling
- ~~add the pry-byebug gem to add improve debugging functionality~~ (now in https://github.com/dxw/dfsseta-apply-for-landing-ruby/pull/30)

Please see individual commits for detailed commentary.

### Screenshot of Stage 1: Pilot chooses destination

![stage_1_choose_destination](https://user-images.githubusercontent.com/20245/227294394-0da4e193-14b7-4937-93fa-31e20177388e.png)
