### PR TITLE
(32) Stage 2: Pilot provides landing and departure dates

### DIFF
--- a/app/controllers/stages/dates_stage_controller.rb
+++ b/app/controllers/stages/dates_stage_controller.rb
@@ -2,5 +2,40 @@
 
 class Stages::DatesStageController < ApplicationController
   def show
+    @dates = DatesForm.new(landing_date: landing_date, departure_date: departure_date)
+  end
+
+  def update
+    @dates = DatesForm.new(
+      landing_date: landing_date,
+      departure_date: departure_date
+    )
+    if @dates.valid?
+      redirect_to(stages_registration_number_path)
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def landing_date
+    Date.new(
+      params.dig(:dates_form, "landing_date(1i)").to_i,
+      params.dig(:dates_form, "landing_date(2i)").to_i,
+      params.dig(:dates_form, "landing_date(3i)").to_i
+    )
+  rescue TypeError, Date::Error
+    nil
+  end
+
+  def departure_date
+    Date.new(
+      params.dig(:dates_form, "departure_date(1i)").to_i,
+      params.dig(:dates_form, "departure_date(2i)").to_i,
+      params.dig(:dates_form, "departure_date(3i)").to_i
+    )
+  rescue TypeError, Date::Error
+    nil
   end
 end

--- a/app/controllers/stages/registration_number_stage_controller.rb
+++ b/app/controllers/stages/registration_number_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::RegistrationNumberStageController < ApplicationController
+  def show
+  end
+end

--- a/app/forms/dates_form.rb
+++ b/app/forms/dates_form.rb
@@ -1,0 +1,26 @@
+class DatesForm
+  include ActiveModel::Model
+
+  attr_accessor :landing_date, :departure_date
+
+  def initialize(landing_date:, departure_date:)
+    @landing_date = landing_date
+    @departure_date = departure_date
+  end
+
+  validates :landing_date, presence: {message: "You must provide a landing date"}
+  validates :departure_date, presence: {message: "You must provide a departure date"}
+
+  validates_comparison_of :landing_date, greater_than: Date.today, message: "Landing date must be in the future"
+  validates_comparison_of :departure_date, greater_than: Date.today, message: "Departure date must be in the future"
+
+  validate :ensure_departure_not_before_landing
+
+  def ensure_departure_not_before_landing
+    return unless landing_date && departure_date
+
+    if landing_date > departure_date
+      errors.add(:base, "Landing date must be earlier than departure date")
+    end
+  end
+end

--- a/app/views/stages/dates_stage/show.html.erb
+++ b/app/views/stages/dates_stage/show.html.erb
@@ -3,7 +3,25 @@
     <div class="row">
       <article class="col">
         <h1 class="govuk-heading-xl">Your dates</h1>
+        <%= form_for @dates, method: :put, url: stages_dates_path do |f| -%>
 
+          <%= f.govuk_error_summary %>
+
+          <%= f.govuk_date_field :landing_date,
+            legend: { text: 'Enter your requested landing date' },
+            hint: { text: 'For example, 31 3 2024' },
+            classes: ["landing"]
+          %>
+
+          <%= f.govuk_date_field :departure_date,
+            legend: { text: 'Enter your requested departure date' },
+            hint: { text: 'For example, 15 4 2024' },
+            classes: ["departure"]
+          %>
+
+
+          <%= f.govuk_submit "Save and continue"%>
+        <% end -%>
       </article>
     </row>
   </section>

--- a/app/views/stages/registration_number_stage/show.html.erb
+++ b/app/views/stages/registration_number_stage/show.html.erb
@@ -1,0 +1,9 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <div class="row">
+      <article class="col">
+        <h1 class="govuk-heading-xl">Your registration number</h1>
+      </article>
+    </row>
+  </section>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
     get :dates, to: "dates_stage#show"
     put :dates, to: "dates_stage#update"
 
-    get :registration_number, to: "registration_number_stage#show"
-    put :registration_number, to: "registration_number_stage#update"
+    get :"registration-number", to: "registration_number_stage#show"
+    put :"registration-number", to: "registration_number_stage#update"
   end
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
+++ b/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Feature: Stage 2: Supply landing and departure dates
+#   So that my craft can be scheduled in to my destination
+#   As a pilot
+#   I want to verify that there is spaceport availability on my preferred
+#     landing and departure dates
+
+RSpec.feature "Stage 2: Supply dates" do
+  # Scenario: Must supply landing and departure dates
+  #   Given I am on the 'provide dates' stage
+  #   When I fail to provide dates
+  #   And I proceed to the next stage
+  #   Then I should see that dates must be provided
+  #
+  #   When I provide landing and departure dates
+  #   And I proceed to the next stage
+  #   Then I should find myself at the 'registration number' stage
+
+  scenario "Stage 2: Supply dates" do
+    given_i_am_at_the_provide_dates_stage
+    when_i_fail_to_provide_dates
+    and_i_proceed_to_the_next_stage
+    then_i_should_see_that_dates_must_be_provided
+
+    when_i_provide_landing_and_departure_dates
+    and_i_proceed_to_the_next_stage
+    then_i_should_find_myself_at_the_registration_number_stage
+  end
+
+  # helpers
+
+  def given_i_am_at_the_provide_dates_stage
+    visit("stages/dates")
+  end
+
+  def when_i_fail_to_provide_dates
+    # noop
+  end
+
+  def and_i_proceed_to_the_next_stage
+    click_button("Save and continue")
+  end
+
+  def then_i_should_see_that_dates_must_be_provided
+    expect(page).to have_content("You must provide a landing date")
+    expect(page).to have_content("You must provide a departure date")
+  end
+
+  def when_i_provide_landing_and_departure_dates
+    within ".landing" do
+      fill_in("Day", with: "10")
+      fill_in("Month", with: "08")
+      fill_in("Year", with: Date.today.year + 1)
+    end
+
+    within ".departure" do
+      fill_in("Day", with: "18")
+      fill_in("Month", with: "08")
+      fill_in("Year", with: Date.today.year + 1)
+    end
+  end
+
+  def then_i_should_find_myself_at_the_registration_number_stage
+    expect(current_path).to eq("/stages/registration-number")
+    expect(page).to have_content("Your registration number")
+  end
+end

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -1,0 +1,120 @@
+RSpec.describe DatesForm do
+  describe "it validates presence of landing_date" do
+    context "when landing_date is missing" do
+      let(:form) { DatesForm.new(landing_date: nil, departure_date: Date.today) }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:landing_date)
+          expect(form.errors.full_messages.join).to match("You must provide a landing date")
+        end
+      end
+    end
+
+    context "when landing_date is present" do
+      let(:form) { DatesForm.new(landing_date: Date.new(2024, 8, 4), departure_date: Date.today) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:landing_date)
+      end
+    end
+  end
+
+  describe "it validates presence of departure_date" do
+    context "when departure_date is missing" do
+      let(:form) { DatesForm.new(landing_date: Date.today, departure_date: nil) }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:departure_date)
+          expect(form.errors.full_messages.join).to match("You must provide a departure date")
+        end
+      end
+    end
+
+    context "when departure_date is present" do
+      let(:form) { DatesForm.new(landing_date: Date.today, departure_date: Date.new(2024, 8, 12)) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:departure_date)
+      end
+    end
+  end
+
+  describe "ensure that departure date is not before landing date" do
+    let(:tomorrow) { Date.today + 1.day }
+    let(:day_after_tomorrow) { Date.today + 2.days }
+
+    context "when departure date IS before landing date" do
+      let(:form) { DatesForm.new(landing_date: day_after_tomorrow, departure_date: tomorrow) }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:base)
+          expect(form.errors.full_messages.join).to match("Landing date must be earlier than departure date")
+        end
+      end
+    end
+
+    context "when departure date is after landing date" do
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: day_after_tomorrow) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:base)
+      end
+    end
+
+    context "when departure date is the same as landing date" do
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: tomorrow) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:base)
+      end
+    end
+  end
+
+  describe "ensure that both landing and departure dates are in the future" do
+    let(:tomorrow) { Date.today + 1.day }
+    let(:yesterday) { Date.today(-1.day) }
+
+    context "when landing date is in the past" do
+      let(:form) { DatesForm.new(landing_date: yesterday, departure_date: tomorrow) }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:landing_date)
+          expect(form.errors.full_messages.join).to match("Landing date must be in the future")
+        end
+      end
+    end
+
+    context "when departure date is in the past" do
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: yesterday) }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:departure_date)
+          expect(form.errors.full_messages.join).to match("Departure date must be in the future")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This follows on from https://github.com/dxw/dfsseta-apply-for-landing-ruby/pull/27 which needs to be merged first**

Once that "Stage 1" work is merged we'll have 3 commits here:

1. minor tweak to url scheme
2. form object to validate the pair of dates
3. implementation of controller / view and acceptance test

Please see individual commits for detailed commentary.

### User story

[Trello card 32](https://trello.com/c/UnyJMgEh/32-stage-2-pilot-provides-landing-and-departure-dates)

- So that my craft can be scheduled in to my destination
- As a pilot
- I want to verify that there is spaceport availability on my preferred landing and departure dates

### Screenshot of Stage 2: Pilot provides landing and departure dates

![stage_2_dates](https://user-images.githubusercontent.com/20245/228328385-7f4f660f-d2c6-4e5c-ab6d-cf3bcaeffa24.png)
