### PR TITLE
Add standard CI workflow file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,6 @@
   "env": {
     "browser": true,
     "es6": true
-  }
+  },
+  "ignorePatterns": ["rollup.config.js"]
 }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,43 @@
+# TODO: Enable GitHub Actions on the repository to test all pull requests
+# https://github.com/<org>/<repo>/actions
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - id: cache-docker
+        uses: actions/cache@v2
+        with:
+          path: /tmp/docker-save
+          key:
+            docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
+            'package-lock.json') }}
+
+      - if: steps.cache-docker.outputs.cache-hit == 'true'
+        name: Load cached Docker image
+        run: docker load -i /tmp/docker-save/snapshot.tar || true
+
+      - name: Build
+        run: script/ci/cibuild
+
+      - name: Test
+        run: script/ci/test
+
+      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+        name: Prepare Docker cache
+        run:
+          mkdir -p /tmp/docker-save && docker save app_test:latest -o
+          /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save

--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,4 @@
 *.gz
 /public/assets/*
 /coverage
+/.idea/

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,5 +25,6 @@
 *.txt
 *.gz
 /public/assets/*
+/app/assets/builds/
 /coverage
 /.idea/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,1 @@
-app/builds/assets
+app/assets/builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,11 +97,7 @@ COPY app ${APP_HOME}/app
 # Create tmp/pids
 RUN mkdir -p tmp/pids
 
-RUN \
-  if [ "$RAILS_ENV" = "production" ]; then \
-  SECRET_KEY_BASE="secret" \
-  bundle exec rake assets:precompile; \
-  fi
+RUN SECRET_KEY_BASE="secret" bundle exec rake assets:precompile
 
 # TODO:
 # In order to expose the current git sha & time of build in the /healthcheck

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,4 +9,4 @@
   this.App || (this.App = {});
 
   this.App.cable = this.ActionCable.createConsumer();
-}.call(this));
+}).call(this);

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,5 +1,5 @@
-$govuk-font-url-function: 'font-url';
-$govuk-image-url-function: 'image-url';
+$govuk-font-url-function: "font-url";
+$govuk-image-url-function: "image-url";
 $govuk-images-path: "govuk-frontend/govuk/assets/images/";
 $govuk-fonts-path: "govuk-frontend/govuk/assets/fonts/";
 $govuk-page-width: 1100px;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,4 +4,3 @@ import * as GOVUKFrontend from "govuk-frontend";
 document.addEventListener("DOMContentLoaded", () => {
   GOVUKFrontend.initAll();
 });
-

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
-// Entry point for the build script in your package.json
-import * as GOVUKFrontend from "govuk-frontend";
-
-document.addEventListener("DOMContentLoaded", () => {
-  GOVUKFrontend.initAll();
-});
+// Initialise the GOVUK Frontend
+//
+// It will only initialise components that are actually present on the page, see:
+// `initAll()` https://github.com/alphagov/govuk-frontend/blob/89b4d21b595916cc477f4f1b12f7509a54735ded/package/govuk/all.js#L2831
+//
+var govuk_initialiser = window.GOVUKFrontend.initAll;
+govuk_initialiser();

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module RailsTemplate
     # Make sure the `form_with` helper generates local forms, instead of defaulting
     # to remote and unobtrusive XHR forms
     config.action_view.form_with_generates_remote_forms = false
+
+    config.active_record.legacy_connection_handling = false
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,8 +2,8 @@
 
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
-  config.annotations.register_directories('features')
-  config.annotations.register_extensions('feature') { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+  config.annotations.register_directories("features")
+  config.annotations.register_extensions("feature") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,8 +9,8 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Configure 'rails notes' to inspect Cucumber files
-  config.annotations.register_directories('features')
-  config.annotations.register_extensions('feature') { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
+  config.annotations.register_directories("features")
+  config.annotations.register_extensions("feature") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/doc/architecture/decisions/0012-standard-terminology.md
+++ b/doc/architecture/decisions/0012-standard-terminology.md
@@ -2,27 +2,41 @@
 
 ## Context
 
-Names are difficult; the fact that the Apply for Landing service will be developed in various languages by teams working largely independently of each other makes them more so. To ensure clarity and lack of ambiguity in communicating about the service, a set of standard terms is needed.
+Names are difficult; the fact that the Apply for Landing service will be
+developed in various languages by teams working largely independently of each
+other makes them more so. To ensure clarity and lack of ambiguity in
+communicating about the service, a set of standard terms is needed.
 
 ## Decision
 
-The following list of terms shall be used to refer to core components of the service unambiguously.
+The following list of terms shall be used to refer to core components of the
+service unambiguously.
 
-* **Arrival Date** The first day for which a Landing Permit is valid.
-* **Departure Date** The final day for which a Landing Permit is valid.
-* **Destination** The location for which a Landing Permit is valid. All Destinations are Landable Bodies.
-* **DfSSETA** Acronym for the Department for Space Strategy and Extra-Terrestrial Affairs. Pronounced /diɛfseɪtə/ (roughly 'dee-eff-SAY-ta')
-* **Landable Body** An astronomical object upon which it is possible for a Spacecraft to land. In practice, this will be a planet or a moon.
-* **Landing Duration** The timespan for which a Landing Permit is valid; the span between a Landing Permit's Arrival and Departure Dates.
-* **Landing Permit** A Permit issued by DfSSETA allowing a Spacecraft to land at a Destination and remain there for a specified Duration.
-* **Landing Permit Identifer** or **Permit ID** A unique identifier assigned to each Landing Permit
-* **Maximum Permitted Stay** The greatest possible Landing Duration for which a Landing Permit may be issued for a given Destination.
-* **Personal Details** Information characterising a Pilot
-* **Pilot** A human responsible for the navigation, direction, and safe handling of a Spacecraft.
-* **Pilot License** A permit authorising a human to act as a Pilot.
-* **Pilot License Identifier** or **License ID** A unique identifier assigned to each Pilot License
-* **Spacecraft** A vehicle capable of transporting a Pilot to a Destination
-* **Spacecraft Registration Identifier** or **Registration ID** A unique identifier assigned to each Spacecraft
+- **Arrival Date** The first day for which a Landing Permit is valid.
+- **Departure Date** The final day for which a Landing Permit is valid.
+- **Destination** The location for which a Landing Permit is valid. All
+  Destinations are Landable Bodies.
+- **DfSSETA** Acronym for the Department for Space Strategy and
+  Extra-Terrestrial Affairs. Pronounced /diɛfseɪtə/ (roughly 'dee-eff-SAY-ta')
+- **Landable Body** An astronomical object upon which it is possible for a
+  Spacecraft to land. In practice, this will be a planet or a moon.
+- **Landing Duration** The timespan for which a Landing Permit is valid; the
+  span between a Landing Permit's Arrival and Departure Dates.
+- **Landing Permit** A Permit issued by DfSSETA allowing a Spacecraft to land at
+  a Destination and remain there for a specified Duration.
+- **Landing Permit Identifer** or **Permit ID** A unique identifier assigned to
+  each Landing Permit
+- **Maximum Permitted Stay** The greatest possible Landing Duration for which a
+  Landing Permit may be issued for a given Destination.
+- **Personal Details** Information characterising a Pilot
+- **Pilot** A human responsible for the navigation, direction, and safe handling
+  of a Spacecraft.
+- **Pilot License** A permit authorising a human to act as a Pilot.
+- **Pilot License Identifier** or **License ID** A unique identifier assigned to
+  each Pilot License
+- **Spacecraft** A vehicle capable of transporting a Pilot to a Destination
+- **Spacecraft Registration Identifier** or **Registration ID** A unique
+  identifier assigned to each Spacecraft
 
 ## Status
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"]
 }


### PR DESCRIPTION
Add a standard CI file to lint, run tests and run brakeman.

Commit some linting fixes.

Ignore the Rollup config in the linter (it does not need linting anyway).

Correct the locations of the build assets in the Stylelint & Prettier ignore files - these files have changed location in Rails 7.