### PR TITLE
Use latest LTS version of Node in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM ruby:3.2.2 as base
 LABEL org.opencontainers.image.authors="contact@dxw.com"
 
-RUN curl -L https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -L https://deb.nodesource.com/setup_18.x | bash -
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \


### PR DESCRIPTION
> **Note**
> CI is currently failing on all PRs because of this issue

Currently, our CI is failing on the `Linting CSS` stage with the error `npx: not found`

I'm not really sure why this is, but using the latest version of Node seems to solve the issue.