### PR TITLE
Exclude compiled JS from ESLinting in pipeline

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,5 @@
     "browser": true,
     "es6": true
   },
-  "ignorePatterns": ["rollup.config.js"]
+  "ignorePatterns": ["rollup.config.js", "app/assets/builds/application.js"]
 }


### PR DESCRIPTION
Our pipeline was failing with an ESLinting error as a result of linting the built JS at `assets/builds/application.js`

```
dfsseta-apply-for-landing-ruby/app/assets/builds/application.js
  1:1151   error  't' is defined but never used                                              no-unused-vars
  1:1329   error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins
  1:2434   error  'global' is not defined                                                    no-undef
... 
✖ 34 problems (34 errors, 0 warnings)
```

In this commit we tell ESLint to ignore this file. 


