### PR TITLE
[15] Stage 3: Supply registration identifier

### DIFF
--- a/app/controllers/stages/dates_stage_controller.rb
+++ b/app/controllers/stages/dates_stage_controller.rb
@@ -20,7 +20,7 @@ class Stages::DatesStageController < ApplicationController
           departure_date: @dates.departure_date
         }
       )
-      redirect_to(stages_registration_number_path)
+      redirect_to(stages_registration_identifier_path)
     else
       render :show
     end

--- a/app/controllers/stages/personal_details_stage_controller.rb
+++ b/app/controllers/stages/personal_details_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::PersonalDetailsStageController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/stages/registration_identifier_stage_controller.rb
+++ b/app/controllers/stages/registration_identifier_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::RegistrationIdentifierStageController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/stages/registration_identifier_stage_controller.rb
+++ b/app/controllers/stages/registration_identifier_stage_controller.rb
@@ -2,7 +2,9 @@
 
 class Stages::RegistrationIdentifierStageController < ApplicationController
   def show
-    @registration_identifier = SpacecraftRegistrationIdentifierForm.new(registration_id: nil)
+    @registration_identifier = SpacecraftRegistrationIdentifierForm.new(
+      registration_id: answers.find(:registration_identifier)&.dig("registration_id")
+    )
   end
 
   def update

--- a/app/controllers/stages/registration_identifier_stage_controller.rb
+++ b/app/controllers/stages/registration_identifier_stage_controller.rb
@@ -2,5 +2,29 @@
 
 class Stages::RegistrationIdentifierStageController < ApplicationController
   def show
+    @registration_identifier = SpacecraftRegistrationIdentifierForm.new(registration_id: nil)
+  end
+
+  def update
+    @registration_identifier = SpacecraftRegistrationIdentifierForm.new(
+      registration_id: params[:spacecraft_registration_identifier_form][:registration_id]
+    )
+
+    if @registration_identifier.valid?
+      answers.save(
+        stage_name: :registration_identifier, answer: {
+          registration_id: @registration_identifier.registration_id
+        }
+      )
+      redirect_to(stages_personal_details_path)
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def answers
+    @answers ||= AnswersRepository.new(session)
   end
 end

--- a/app/controllers/stages/registration_number_stage_controller.rb
+++ b/app/controllers/stages/registration_number_stage_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class Stages::RegistrationNumberStageController < ApplicationController
-  def show
-  end
-end

--- a/app/forms/spacecraft_registration_identifier_form.rb
+++ b/app/forms/spacecraft_registration_identifier_form.rb
@@ -1,0 +1,18 @@
+class SpacecraftRegistrationIdentifierForm
+  include ActiveModel::Model
+
+  attr_accessor :registration_id
+
+  def initialize(registration_id:)
+    @registration_id = registration_id
+  end
+
+  validates :registration_id,
+    presence: {
+      message: "You must provide a Spacecraft Registration Identifier"
+    },
+    format: {
+      with: /[A-Z]{3}\d{3}[A-Z]/,
+      message: "You must provide a Spacecraft Registration Identifier in the form ABC123A (3 letters - 3 digits - 1 letter)"
+    }
+end

--- a/app/views/stages/personal_details_stage/show.html.erb
+++ b/app/views/stages/personal_details_stage/show.html.erb
@@ -1,0 +1,9 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <div class="row">
+      <article class="col">
+        <h1 class="govuk-heading-xl">Your personal details</h1>
+      </article>
+    </row>
+  </section>
+</main>

--- a/app/views/stages/registration_identifier_stage/show.html.erb
+++ b/app/views/stages/registration_identifier_stage/show.html.erb
@@ -2,7 +2,18 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your registration identifier</h1>
+        <h1 class="govuk-heading-xl">Your registration ID</h1>
+
+        <p class="govuk-body">We need to record your Spacecraft Registration Identifier.</p>
+
+        <%= form_for @registration_identifier, method: :put, url: stages_registration_identifier_path do |f| -%>
+
+          <%= f.govuk_error_summary %>
+
+          <%= f.govuk_text_field :registration_id, label: {text: 'Registration ID'}, width: 'one-half' %>
+
+          <%= f.govuk_submit "Save and continue"%>
+        <% end -%>
       </article>
     </row>
   </section>

--- a/app/views/stages/registration_identifier_stage/show.html.erb
+++ b/app/views/stages/registration_identifier_stage/show.html.erb
@@ -2,7 +2,7 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your registration number</h1>
+        <h1 class="govuk-heading-xl">Your registration identifier</h1>
       </article>
     </row>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
     get :dates, to: "dates_stage#show"
     put :dates, to: "dates_stage#update"
 
-    get :"registration-number", to: "registration_number_stage#show"
-    put :"registration-number", to: "registration_number_stage#update"
+    get :"registration-identifier", to: "registration_identifier_stage#show"
+    put :"registration-identifier", to: "registration_identifier_stage#update"
   end
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
 
     get :"registration-identifier", to: "registration_identifier_stage#show"
     put :"registration-identifier", to: "registration_identifier_stage#update"
+
+    get :"personal-details", to: "personal_details_stage#show"
+    put :"personal-details", to: "personal_details_stage#update"
   end
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/spec/controllers/registration_indentifier_stage_controller_spec.rb
+++ b/spec/controllers/registration_indentifier_stage_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Stages::RegistrationIdentifierStageController do
+  let(:repository) do
+    instance_double(AnswersRepository).tap do |repository|
+      allow(repository).to receive(:find)
+      allow(repository).to receive(:save)
+    end
+  end
+
+  before { allow(AnswersRepository).to receive(:new).and_return(repository) }
+
+  describe "GET to :show" do
+    it "asks the repository to find the user's answer to this stage" do
+      get :show
+
+      expect(repository).to have_received(:find).with(:registration_identifier)
+    end
+  end
+
+  describe "PUT to :update" do
+    it "asks the repository to save the user's answer to this stage" do
+      put :update, params: {spacecraft_registration_identifier_form: {registration_id: "XXX111X"}}
+
+      expect(repository).to have_received(:save).with(
+        stage_name: :registration_identifier,
+        answer: {registration_id: "XXX111X"}
+      )
+    end
+  end
+end

--- a/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
+++ b/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Stage 2: Supply dates" do
 
   def then_i_should_find_myself_at_the_registration_identifier_stage
     expect(current_path).to eq("/stages/registration-identifier")
-    expect(page).to have_content("Your registration identifier")
+    expect(page).to have_content("Your registration ID")
   end
 
   def given_i_have_chosen_landing_and_departure_dates

--- a/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
+++ b/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Stage 2: Supply dates" do
   #
   #   When I provide landing and departure dates
   #   And I proceed to the next stage
-  #   Then I should find myself at the 'registration number' stage
+  #   Then I should find myself at the 'registration identifier' stage
 
   scenario "Stage 2: Must supply dates" do
     given_i_am_at_the_provide_dates_stage
@@ -25,7 +25,7 @@ RSpec.feature "Stage 2: Supply dates" do
 
     when_i_provide_landing_and_departure_dates
     and_i_proceed_to_the_next_stage
-    then_i_should_find_myself_at_the_registration_number_stage
+    then_i_should_find_myself_at_the_registration_identifier_stage
   end
 
   # Scenario: May change dates
@@ -74,9 +74,9 @@ RSpec.feature "Stage 2: Supply dates" do
     end
   end
 
-  def then_i_should_find_myself_at_the_registration_number_stage
-    expect(current_path).to eq("/stages/registration-number")
-    expect(page).to have_content("Your registration number")
+  def then_i_should_find_myself_at_the_registration_identifier_stage
+    expect(current_path).to eq("/stages/registration-identifier")
+    expect(page).to have_content("Your registration identifier")
   end
 
   def given_i_have_chosen_landing_and_departure_dates

--- a/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
+++ b/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
@@ -6,16 +6,6 @@
 #   I want to supply a validated "Spacecraft Registration Identifier"
 
 RSpec.feature "Stage 3: Supply registration identifier" do
-  # Scenario: Must supply Spacecraft Registration Identifier
-  #   Given I am on the 'registration identifier' stage
-  #   When I fail to provide a valid identifier
-  #   And I proceed to the next stage
-  #   Then I should see that the Spacecraft Registration Identifier must be provided
-  #
-  #   When I provide Spacecraft Registration Identifier
-  #   And I proceed to the next stage
-  #   Then I should find myself at the 'personal details' stages
-
   scenario "Stage 3: must supply registration identifier" do
     given_i_am_on_the_registration_identifier_stage
     when_i_fail_to_provide_a_valid_identifier
@@ -26,12 +16,6 @@ RSpec.feature "Stage 3: Supply registration identifier" do
     and_i_proceed_to_the_next_stage
     then_i_should_find_myself_at_the_personal_details_stage
   end
-
-  # Scenario: May change registration identifier
-  #   Given I have supplied my registration identifier
-  #   And I proceed to the next stage
-  #   And I have returned to the 'registration identifier' stage
-  #   Then I should see my saved answer from earlier
 
   scenario "Stage 3: may change registration identifier" do
     given_i_have_supplied_my_registration_identifier

--- a/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
+++ b/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
@@ -27,6 +27,19 @@ RSpec.feature "Stage 3: Supply registration identifier" do
     then_i_should_find_myself_at_the_personal_details_stage
   end
 
+  # Scenario: May change registration identifier
+  #   Given I have supplied my registration identifier
+  #   And I proceed to the next stage
+  #   And I have returned to the 'registration identifier' stage
+  #   Then I should see my saved answer from earlier
+
+  scenario "Stage 3: may change registration identifier" do
+    given_i_have_supplied_my_registration_identifier
+    and_i_proceed_to_the_next_stage
+    and_i_have_returned_to_the_registration_identifier_stage
+    then_i_should_see_my_saved_answer_from_earlier
+  end
+
   def given_i_am_on_the_registration_identifier_stage
     visit("stages/registration-identifier")
   end
@@ -50,5 +63,18 @@ RSpec.feature "Stage 3: Supply registration identifier" do
   def then_i_should_find_myself_at_the_personal_details_stage
     expect(current_path).to eq("/stages/personal-details")
     expect(page).to have_content("Your personal details")
+  end
+
+  def given_i_have_supplied_my_registration_identifier
+    given_i_am_on_the_registration_identifier_stage
+    when_i_provide_spacecraft_registration_identifier
+  end
+
+  def and_i_have_returned_to_the_registration_identifier_stage
+    given_i_am_on_the_registration_identifier_stage
+  end
+
+  def then_i_should_see_my_saved_answer_from_earlier
+    expect(page).to have_field("Registration ID", with: "ABC123X")
   end
 end

--- a/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
+++ b/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Feature: Stage 3: Supply "Spacecraft Registration Identifier"
+#   So that my "reg" can be checked by "the authorities"
+#   As a pilot
+#   I want to supply a validated "Spacecraft Registration Identifier"
+
+RSpec.feature "Stage 3: Supply registration identifier" do
+  # Scenario: Must supply Spacecraft Registration Identifier
+  #   Given I am on the 'registration identifier' stage
+  #   When I fail to provide a valid identifier
+  #   And I proceed to the next stage
+  #   Then I should see that the Spacecraft Registration Identifier must be provided
+  #
+  #   When I provide Spacecraft Registration Identifier
+  #   And I proceed to the next stage
+  #   Then I should find myself at the 'personal details' stages
+
+  scenario "Stage 3: must supply registration identifier" do
+    given_i_am_on_the_registration_identifier_stage
+    when_i_fail_to_provide_a_valid_identifier
+    and_i_proceed_to_the_next_stage
+    then_i_should_see_that_the_spacecraft_registration_identifier_must_be_provided
+
+    when_i_provide_spacecraft_registration_identifier
+    and_i_proceed_to_the_next_stage
+    then_i_should_find_myself_at_the_personal_details_stage
+  end
+
+  def given_i_am_on_the_registration_identifier_stage
+    visit("stages/registration-identifier")
+  end
+
+  def when_i_fail_to_provide_a_valid_identifier
+    # noop
+  end
+
+  def and_i_proceed_to_the_next_stage
+    click_button("Save and continue")
+  end
+
+  def then_i_should_see_that_the_spacecraft_registration_identifier_must_be_provided
+    expect(page).to have_content("You must provide a Spacecraft Registration Identifier")
+  end
+
+  def when_i_provide_spacecraft_registration_identifier
+    fill_in("Registration ID", with: "ABC123X")
+  end
+
+  def then_i_should_find_myself_at_the_personal_details_stage
+    expect(current_path).to eq("/stages/personal-details")
+    expect(page).to have_content("Your personal details")
+  end
+end

--- a/spec/forms/spacecraft_registration_identifier_form_spec.rb
+++ b/spec/forms/spacecraft_registration_identifier_form_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe SpacecraftRegistrationIdentifierForm do
+  describe "it validates presence of SpacecraftRegistrationIdentifier" do
+    context "when SpacecraftRegistrationIdentifier is blank" do
+      let(:form) { SpacecraftRegistrationIdentifierForm.new(registration_id: "") }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:registration_id)
+          expect(form.errors.full_messages.join).to match("You must provide a Spacecraft Registration Identifier")
+        end
+      end
+    end
+
+    context "when SpacecraftRegistrationIdentifier is present" do
+      let(:form) { SpacecraftRegistrationIdentifierForm.new(registration_id: "ABC123A") }
+
+      it "should not flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:registration_id)
+      end
+    end
+  end
+
+  describe "it validates the format of the Registration ID" do
+    context "when it conforms to [3 letters - 3 digits - 1 letter]" do
+      let(:form) { SpacecraftRegistrationIdentifierForm.new(registration_id: "XXX999X") }
+
+      it "should not flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:registration_id)
+      end
+    end
+
+    context "when it does NOT conform to (3 letters - 3 digits - 1 letter)" do
+      let(:form) { SpacecraftRegistrationIdentifierForm.new(registration_id: "XX1234XX") }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:registration_id)
+          expect(form.errors.full_messages.join).to match("You must provide a Spacecraft Registration Identifier in the form ABC123A")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello 15](https://trello.com/c/BvEYSrto/15-stage-3-supply-spacecraft-registration-identifier)

## Stage 3: Pilot supplies spacecraft registration identifier

The registration identifier needs to be in the `XXX111X` format.

See individual commit messages for details.

<img width="1009" alt="stage_3_supply_registration_information" src="https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/fcd1b513-46d3-4cac-8865-5e4b466e09bf">
