### PR TITLE
[18] Stage 4: supply personal details

### DIFF
--- a/app/controllers/stages/check_your_answers_stage_controller.rb
+++ b/app/controllers/stages/check_your_answers_stage_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Stages::CheckYourAnswersStageController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/stages/personal_details_stage_controller.rb
+++ b/app/controllers/stages/personal_details_stage_controller.rb
@@ -2,5 +2,37 @@
 
 class Stages::PersonalDetailsStageController < ApplicationController
   def show
+    @personal_details = PersonalDetailsForm.new(
+      fullname: answers.find(:personal_details)&.dig("fullname"),
+      email: answers.find(:personal_details)&.dig("email"),
+      licence_id: answers.find(:personal_details)&.dig("licence_id")
+    )
+  end
+
+  def update
+    @personal_details = PersonalDetailsForm.new(
+      fullname: params[:personal_details_form][:fullname],
+      email: params[:personal_details_form][:email],
+      licence_id: params[:personal_details_form][:licence_id]
+    )
+
+    if @personal_details.valid?
+      answers.save(
+        stage_name: :personal_details, answer: {
+          fullname: @personal_details.fullname,
+          email: @personal_details.email,
+          licence_id: @personal_details.licence_id
+        }
+      )
+      redirect_to(stages_check_your_answers_path)
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def answers
+    @answers ||= AnswersRepository.new(session)
   end
 end

--- a/app/forms/personal_details_form.rb
+++ b/app/forms/personal_details_form.rb
@@ -1,0 +1,34 @@
+class PersonalDetailsForm
+  include ActiveModel::Model
+
+  attr_accessor :fullname, :email, :licence_id
+
+  def initialize(fullname: nil, email: nil, licence_id: nil)
+    @fullname = fullname
+    @email = email
+    @licence_id = licence_id
+  end
+
+  validates :fullname,
+    presence: {
+      message: "Enter your full name"
+    }
+
+  validates :email,
+    presence: {
+      message: "Enter your email address"
+    },
+    format: {
+      with: /.+@.+\..+/,
+      message: "Enter an email address in the correct format, like name@example.com"
+    }
+
+  validates :licence_id,
+    presence: {
+      message: "Enter your Licence ID"
+    },
+    length: {
+      minimum: 8,
+      message: "Your Licence ID must contain at least 8 characters"
+    }
+end

--- a/app/views/stages/check_your_answers_stage/show.erb
+++ b/app/views/stages/check_your_answers_stage/show.erb
@@ -1,0 +1,9 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <div class="row">
+      <article class="col">
+        <h1 class="govuk-heading-xl">Check your answers</h1>
+      </article>
+    </row>
+  </section>
+</main>

--- a/app/views/stages/personal_details_stage/show.html.erb
+++ b/app/views/stages/personal_details_stage/show.html.erb
@@ -3,6 +3,20 @@
     <div class="row">
       <article class="col">
         <h1 class="govuk-heading-xl">Your personal details</h1>
+        <p class="govuk-body">We need to record some details about you.</p>
+
+        <%= form_for @personal_details, method: :put, url: stages_personal_details_path do |f| -%>
+
+          <%= f.govuk_error_summary %>
+
+          <%= f.govuk_text_field :fullname, label: {text: 'Full name'}, width: 'one-half' %>
+
+          <%= f.govuk_text_field :email, label: {text: 'Email address'}, width: 'one-half' %>
+
+          <%= f.govuk_text_field :licence_id, label: {text: 'Licence ID'}, width: 'one-half' %>
+
+          <%= f.govuk_submit "Save and continue"%>
+        <% end -%>
       </article>
     </row>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
 
     get :"personal-details", to: "personal_details_stage#show"
     put :"personal-details", to: "personal_details_stage#update"
+
+    get :"check-your-answers", to: "check_your_answers_stage#show"
+    put :"check-your-answers", to: "check_your_answers_stage#update"
   end
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/spec/features/pilot/stage_4_supply_personal_information_spec.rb
+++ b/spec/features/pilot/stage_4_supply_personal_information_spec.rb
@@ -6,16 +6,6 @@
 #   I want to supply the requested personal details
 
 RSpec.feature "Stage 4: Supply personal details" do
-  # Scenario: Must supply personal details
-  #   Given I am on the 'personal details' stage
-  #   When I fail to provide the requested personal details
-  #   And I proceed to the next stage
-  #   Then I should see that personal details must be provided
-  #
-  #   When I provide personal details
-  #   And I proceed to the next stage
-  #   Then I should find myself at the 'check your answers' stage
-
   scenario "Stage 3: must supply personal details" do
     given_i_am_on_the_personal_details_stage
     when_i_fail_to_provide_the_requested_personal_details
@@ -26,12 +16,6 @@ RSpec.feature "Stage 4: Supply personal details" do
     and_i_proceed_to_the_next_stage
     then_i_should_find_myself_at_the_check_your_answers_stage
   end
-
-  # Scenario: May change personal details
-  #   Given I have supplied my personal details
-  #   And I proceed to the next stage
-  #   And I have returned to the 'personal details' stage
-  #   Then I should see my saved answers from earlier
 
   scenario "Stage 3: may change personal details" do
     given_i_have_supplied_my_personal_details

--- a/spec/features/pilot/stage_4_supply_personal_information_spec.rb
+++ b/spec/features/pilot/stage_4_supply_personal_information_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Feature: Stage 4: Supply personal details
+#   So that my personal background can be checked "the authorities"
+#   As a pilot
+#   I want to supply the requested personal details
+
+RSpec.feature "Stage 4: Supply personal details" do
+  # Scenario: Must supply personal details
+  #   Given I am on the 'personal details' stage
+  #   When I fail to provide the requested personal details
+  #   And I proceed to the next stage
+  #   Then I should see that personal details must be provided
+  #
+  #   When I provide personal details
+  #   And I proceed to the next stage
+  #   Then I should find myself at the 'check your answers' stage
+
+  scenario "Stage 3: must supply personal details" do
+    given_i_am_on_the_personal_details_stage
+    when_i_fail_to_provide_the_requested_personal_details
+    and_i_proceed_to_the_next_stage
+    then_i_should_see_that_personal_details_must_be_provided
+
+    when_i_provide_personal_details
+    and_i_proceed_to_the_next_stage
+    then_i_should_find_myself_at_the_check_your_answers_stage
+  end
+
+  # Scenario: May change personal details
+  #   Given I have supplied my personal details
+  #   And I proceed to the next stage
+  #   And I have returned to the 'personal details' stage
+  #   Then I should see my saved answers from earlier
+
+  scenario "Stage 3: may change personal details" do
+    given_i_have_supplied_my_personal_details
+    and_i_proceed_to_the_next_stage
+    and_i_have_returned_to_the_personal_details_stage
+    then_i_should_see_my_saved_answers_from_earlier
+  end
+
+  def given_i_am_on_the_personal_details_stage
+    visit("stages/personal-details")
+  end
+
+  def when_i_fail_to_provide_the_requested_personal_details
+    # noop
+  end
+
+  def and_i_proceed_to_the_next_stage
+    click_button("Save and continue")
+  end
+
+  def then_i_should_see_that_personal_details_must_be_provided
+    expect(page).to have_content("Enter your full name")
+    expect(page).to have_content("Enter your email address")
+    expect(page).to have_content("Enter your Licence ID")
+  end
+
+  def when_i_provide_personal_details
+    fill_in("Full name", with: "Roger Smith")
+    fill_in("Email address", with: "roger@example.com")
+    fill_in("Licence ID", with: "12345678")
+  end
+
+  def then_i_should_find_myself_at_the_check_your_answers_stage
+    expect(current_path).to eq("/stages/check-your-answers")
+    expect(page).to have_content("Check your answers")
+  end
+
+  def given_i_have_supplied_my_personal_details
+    given_i_am_on_the_personal_details_stage
+    when_i_provide_personal_details
+  end
+
+  def and_i_have_returned_to_the_personal_details_stage
+    given_i_am_on_the_personal_details_stage
+  end
+
+  def then_i_should_see_my_saved_answers_from_earlier
+    expect(page).to have_field("Full name", with: "Roger Smith")
+    expect(page).to have_field("Email address", with: "roger@example.com")
+    expect(page).to have_field("Licence ID", with: "12345678")
+  end
+end

--- a/spec/forms/personal_details_form_spec.rb
+++ b/spec/forms/personal_details_form_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe PersonalDetailsForm do
+  describe ":fullname field" do
+    context "when :fullname is blank" do
+      let(:form) { PersonalDetailsForm.new(fullname: "") }
+
+      it "should flag an error" do
+        form.valid?
+
+        aggregate_failures do
+          expect(form.errors).to include(:fullname)
+          expect(form.errors.full_messages.join).to match("Enter your full name")
+        end
+      end
+    end
+
+    context "when :fullname is present" do
+      let(:form) { PersonalDetailsForm.new(fullname: "Roger Smith") }
+
+      it "should not flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:fullname)
+      end
+    end
+  end
+
+  describe ":email field" do
+    describe "it validates presence of :email" do
+      context "when :email is blank" do
+        let(:form) { PersonalDetailsForm.new(email: "") }
+
+        it "should flag an error" do
+          form.valid?
+
+          aggregate_failures do
+            expect(form.errors).to include(:email)
+            expect(form.errors.full_messages.join).to match("Enter your email address")
+          end
+        end
+      end
+
+      context "when :email is present, in valid format" do
+        let(:form) { PersonalDetailsForm.new(email: "roger@example.com") }
+
+        it "should not flag an error" do
+          form.valid?
+
+          expect(form.errors).to_not include(:email)
+        end
+      end
+    end
+
+    describe "validates format" do
+      context "when it does not have an @ symbol" do
+        let(:form) { PersonalDetailsForm.new(email: "roger.example.com") }
+
+        it "should flag an error" do
+          form.valid?
+
+          aggregate_failures do
+            expect(form.errors).to include(:email)
+            expect(form.errors.full_messages.join).to match(
+              "Enter an email address in the correct format, like name@example.com"
+            )
+          end
+        end
+      end
+
+      context "when it does not end with an top-level domain" do
+        let(:form) { PersonalDetailsForm.new(email: "roger@example") }
+
+        it "should flag an error" do
+          form.valid?
+
+          aggregate_failures do
+            expect(form.errors).to include(:email)
+            expect(form.errors.full_messages.join).to match("Enter an email address in the correct format, like name@example.com")
+          end
+        end
+      end
+    end
+  end
+
+  describe ":licence_id field" do
+    describe "it validates presence of :licence_id" do
+      context "when :licence_id is blank" do
+        let(:form) { PersonalDetailsForm.new(licence_id: "") }
+
+        it "should flag an error" do
+          form.valid?
+
+          aggregate_failures do
+            expect(form.errors).to include(:licence_id)
+            expect(form.errors.full_messages.join).to match("Enter your Licence ID")
+          end
+        end
+      end
+
+      context "when :licence_id is present, in valid format" do
+        let(:form) { PersonalDetailsForm.new(licence_id: "12345678") }
+
+        it "should not flag an error" do
+          form.valid?
+
+          expect(form.errors).to_not include(:licence_id)
+        end
+      end
+    end
+
+    describe "validates format" do
+      context "when it is less than eight characters" do
+        let(:form) { PersonalDetailsForm.new(licence_id: "1234567") }
+
+        it "should flag an error" do
+          form.valid?
+
+          aggregate_failures do
+            expect(form.errors).to include(:licence_id)
+            expect(form.errors.full_messages.join).to match("Your Licence ID must contain at least 8 characters")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**NB: [PR 95](https://github.com/dxw/dfsseta-apply-for-landing-ruby/pull/95) Stage 3: Supply registration identifier needs to be merged first**

This PR implements stage 4 of 5 in the "Apply for a Landing" workflow.

See [Trello 18](https://trello.com/c/hMAy7QYS/38-stage-4-supply-personal-details)

The final stage will be "[Check your answers](https://design-system.service.gov.uk/patterns/check-answers/)". The journey then culminates in a "[Success confirmation panel](https://design-system.service.gov.uk/components/panel/)" page.

![stage4_personal_details](https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/a47282e5-3177-437e-b8c6-4f35b08caa1c)
