### PR TITLE
Move H1 heading below error messages

### DIFF
--- a/app/views/stages/dates_stage/show.html.erb
+++ b/app/views/stages/dates_stage/show.html.erb
@@ -2,10 +2,11 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your dates</h1>
         <%= form_for @dates, method: :put, url: stages_dates_path do |f| -%>
 
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-xl">Your dates</h1>
 
           <%= f.govuk_date_field :landing_date,
             legend: { text: 'Enter your requested landing date' },

--- a/app/views/stages/destination_stage/show.html.erb
+++ b/app/views/stages/destination_stage/show.html.erb
@@ -2,11 +2,11 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your destination</h1>
-
         <%= form_for @destination, method: :put, url: stages_destination_path do |f| -%>
 
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-xl">Your destination</h1>
 
           <%= f.govuk_collection_radio_buttons :destination_id,
             @landable_bodies,

--- a/app/views/stages/personal_details_stage/show.html.erb
+++ b/app/views/stages/personal_details_stage/show.html.erb
@@ -2,12 +2,12 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your personal details</h1>
-        <p class="govuk-body">We need to record some details about you.</p>
-
         <%= form_for @personal_details, method: :put, url: stages_personal_details_path do |f| -%>
 
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-xl">Your personal details</h1>
+          <p class="govuk-body">We need to record some details about you.</p>
 
           <%= f.govuk_text_field :fullname, label: {text: 'Full name'}, width: 'one-half' %>
 

--- a/app/views/stages/registration_identifier_stage/show.html.erb
+++ b/app/views/stages/registration_identifier_stage/show.html.erb
@@ -2,13 +2,12 @@
   <section class="container">
     <div class="row">
       <article class="col">
-        <h1 class="govuk-heading-xl">Your registration ID</h1>
-
-        <p class="govuk-body">We need to record your Spacecraft Registration Identifier.</p>
-
         <%= form_for @registration_identifier, method: :put, url: stages_registration_identifier_path do |f| -%>
 
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-xl">Your registration ID</h1>
+          <p class="govuk-body">We need to record your Spacecraft Registration Identifier.</p>
 
           <%= f.govuk_text_field :registration_id, label: {text: 'Registration ID'}, width: 'one-half' %>
 


### PR DESCRIPTION
[Trello 40](https://trello.com/c/euq784Sd/40-adjust-layout-to-move-heading-below-error-summary): As per https://design-system.service.gov.uk/components/error-summary/#where-to-put-the-error-summary it's more helpful if the error messages come at the top of the form when there are validation error messages to show.

## After

![heading_below_error_messages](https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/af519fe5-eb11-4c23-a124-2e2e7c20a356)

## Before

![stage4_personal_details](https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/cb6db8a0-5212-45d0-a5f9-3777c97faf3b)
