### PR TITLE
(41) Improve error messages to conform to GOV.UK guidance

### DIFF
--- a/app/forms/dates_form.rb
+++ b/app/forms/dates_form.rb
@@ -8,8 +8,8 @@ class DatesForm
     @departure_date = departure_date
   end
 
-  validates :landing_date, presence: {message: "You must provide a landing date"}
-  validates :departure_date, presence: {message: "You must provide a departure date"}
+  validates :landing_date, presence: {message: "Enter a landing date"}
+  validates :departure_date, presence: {message: "Enter a departure date"}
 
   validates_comparison_of :landing_date, greater_than: Date.today, message: "Landing date must be in the future"
   validates_comparison_of :departure_date, greater_than: Date.today, message: "Departure date must be in the future"

--- a/app/forms/destination_form.rb
+++ b/app/forms/destination_form.rb
@@ -7,5 +7,5 @@ class DestinationForm
     @destination_id = destination_id
   end
 
-  validates :destination_id, presence: {message: "You must choose a destination"}
+  validates :destination_id, presence: {message: "Choose a destination"}
 end

--- a/app/forms/spacecraft_registration_identifier_form.rb
+++ b/app/forms/spacecraft_registration_identifier_form.rb
@@ -9,10 +9,10 @@ class SpacecraftRegistrationIdentifierForm
 
   validates :registration_id,
     presence: {
-      message: "You must provide a Spacecraft Registration Identifier"
+      message: "Enter a Spacecraft Registration Identifier"
     },
     format: {
       with: /[A-Z]{3}\d{3}[A-Z]/,
-      message: "You must provide a Spacecraft Registration Identifier in the form ABC123A (3 letters - 3 digits - 1 letter)"
+      message: "Enter a Spacecraft Registration Identifier in the form ABC123A (3 letters - 3 digits - 1 letter)"
     }
 end

--- a/spec/features/pilot/stage_1_choose_destination_spec.rb
+++ b/spec/features/pilot/stage_1_choose_destination_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Stage 1: Must choose destination" do
   end
 
   def then_i_should_see_that_a_destination_must_be_chosen
-    expect(page).to have_content("You must choose a destination")
+    expect(page).to have_content("Choose a destination")
   end
 
   def when_choose_a_destination

--- a/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
+++ b/spec/features/pilot/stage_2_supply_landing_and_departure_dates_spec.rb
@@ -56,8 +56,8 @@ RSpec.feature "Stage 2: Supply dates" do
   end
 
   def then_i_should_see_that_dates_must_be_provided
-    expect(page).to have_content("You must provide a landing date")
-    expect(page).to have_content("You must provide a departure date")
+    expect(page).to have_content("Enter a landing date")
+    expect(page).to have_content("Enter a departure date")
   end
 
   def when_i_provide_landing_and_departure_dates

--- a/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
+++ b/spec/features/pilot/stage_3_supply_registration_identifier_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Stage 3: Supply registration identifier" do
   end
 
   def then_i_should_see_that_the_spacecraft_registration_identifier_must_be_provided
-    expect(page).to have_content("You must provide a Spacecraft Registration Identifier")
+    expect(page).to have_content("Enter a Spacecraft Registration Identifier")
   end
 
   def when_i_provide_spacecraft_registration_identifier

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DatesForm do
 
         aggregate_failures do
           expect(form.errors).to include(:landing_date)
-          expect(form.errors.full_messages.join).to match("You must provide a landing date")
+          expect(form.errors.full_messages.join).to match("Enter a landing date")
         end
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe DatesForm do
 
         aggregate_failures do
           expect(form.errors).to include(:departure_date)
-          expect(form.errors.full_messages.join).to match("You must provide a departure date")
+          expect(form.errors.full_messages.join).to match("Enter a departure date")
         end
       end
     end

--- a/spec/forms/destination_form_spec.rb
+++ b/spec/forms/destination_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DestinationForm do
 
         aggregate_failures do
           expect(form.errors).to include(:destination_id)
-          expect(form.errors.full_messages.join).to match("You must choose a destination")
+          expect(form.errors.full_messages.join).to match("Choose a destination")
         end
       end
     end

--- a/spec/forms/spacecraft_registration_identifier_form_spec.rb
+++ b/spec/forms/spacecraft_registration_identifier_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SpacecraftRegistrationIdentifierForm do
 
         aggregate_failures do
           expect(form.errors).to include(:registration_id)
-          expect(form.errors.full_messages.join).to match("You must provide a Spacecraft Registration Identifier")
+          expect(form.errors.full_messages.join).to match("Enter a Spacecraft Registration Identifier")
         end
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe SpacecraftRegistrationIdentifierForm do
 
         aggregate_failures do
           expect(form.errors).to include(:registration_id)
-          expect(form.errors.full_messages.join).to match("You must provide a Spacecraft Registration Identifier in the form ABC123A")
+          expect(form.errors.full_messages.join).to match("Enter a Spacecraft Registration Identifier in the form ABC123A")
         end
       end
     end


### PR DESCRIPTION
In this PR with improve the validation error messages to conform to the [guidance at: GOV.UK](https://design-system.service.gov.uk/components/text-input/#if-the-input-is-empty).

Stage 4 was fixed up during code review: https://github.com/dxw/dfsseta-apply-for-landing-ruby/pull/98#discussion_r1328778013