### PR TITLE
Configure renovate to auto-merge patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": [
+      "config:base",
+      ":approveMajorUpdates",
+      ":automergeLinters",
+      ":automergePatch",
+      ":automergePr",
+      ":automergeRequireAllStatusChecks",
+      ":automergeTesters",
+      ":dependencyDashboard",
+      ":enablePreCommit",
+      ":combinePatchMinorReleases"
+    ],
+    "timezone": "Europe/London",
+    "platformAutomerge": true,
+    "automergeSchedule": [
+      "after 10am every weekday",
+      "before 4pm every weekday"
+    ],
+    "minimumReleaseAge": "3 days",
+    "packageRules": [
+      {
+        "matchDatasources": ["npm"],
+        "minimumReleaseAge": "5 days"
+      }
+    ],
+    "labels": ["dependencies"]
 }


### PR DESCRIPTION
To aid maintenance, we want our renovate config to
auto-merge patches. This is similar to the  [dxw config],
though we use `automergePatch` rather than
`automergeMinor`.

This is a more cautious strategy, more appropriate
for a citizen-facing service.

See [Renovate docs] for detail on the Renovate config
settings.



[dxw config]: https://github.com/dxw/renovate-config/blob/main/internal.json
[Renovate docs]: https://docs.renovatebot.com/presets-default/