### PR TITLE
(39) Stage 5: Check your answers

### DIFF
--- a/app/controllers/stages/check_your_answers_stage_controller.rb
+++ b/app/controllers/stages/check_your_answers_stage_controller.rb
@@ -2,6 +2,12 @@
 
 class Stages::CheckYourAnswersStageController < ApplicationController
   def show
+    stages_questions_and_answers
+  end
+
+  private
+
+  def stages_questions_and_answers
     @stages_questions_and_answers = [
       CheckYourAnswers::Stage.new(
         name: "destination",
@@ -12,10 +18,11 @@ class Stages::CheckYourAnswersStageController < ApplicationController
           CheckYourAnswers::Question.new(
             ref: :destination,
             title: "Destination",
-            answer: "Saturn (core)"
+            answer: destination_answer
           )
         ]
       ),
+
       CheckYourAnswers::Stage.new(
         name: "dates",
         title: "Dates",
@@ -25,15 +32,70 @@ class Stages::CheckYourAnswersStageController < ApplicationController
           CheckYourAnswers::Question.new(
             ref: :landing_date,
             title: "Requested landing date",
-            answer: "10 August 2024"
+            answer: date_answer("landing_date")
           ),
           CheckYourAnswers::Question.new(
             ref: :departure_date,
             title: "Requested departure date",
-            answer: "18 August 2024"
+            answer: date_answer("departure_date")
+          )
+        ]
+      ),
+
+      CheckYourAnswers::Stage.new(
+        name: "registration_identifier",
+        title: "Spacecraft Registration Identifier",
+        link_path: stages_registration_identifier_path,
+        link_text: "Registration ID",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :registration_id,
+            title: "Registration ID",
+            answer: answers.find(:registration_identifier)&.dig("registration_id")
+          )
+        ]
+      ),
+
+      CheckYourAnswers::Stage.new(
+        name: "personal_detals",
+        title: "Personal details",
+        link_path: stages_personal_details_path,
+        link_text: "personal details",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :fullname,
+            title: "Name",
+            answer: answers.find(:personal_details)&.dig("fullname")
+          ),
+          CheckYourAnswers::Question.new(
+            ref: :email,
+            title: "Email address",
+            answer: answers.find(:personal_details)&.dig("email")
+          ),
+          CheckYourAnswers::Question.new(
+            ref: :licence_id,
+            title: "Licence ID",
+            answer: answers.find(:personal_details)&.dig("licence_id")
           )
         ]
       )
     ]
+  end
+
+  def answers
+    @answers ||= AnswersRepository.new(session)
+  end
+
+  def destination_answer
+    LANDABLE_BODIES
+      .find { |body| body.id == answers.find(:destination)&.dig("destination_id") }
+      &.name
+  end
+
+  def date_answer(date_name)
+    Date.parse(answers.find(:dates)&.dig(date_name))
+      .strftime("%e %B %Y")
+  rescue TypeError, Date::Error
+    nil
   end
 end

--- a/app/controllers/stages/check_your_answers_stage_controller.rb
+++ b/app/controllers/stages/check_your_answers_stage_controller.rb
@@ -2,5 +2,38 @@
 
 class Stages::CheckYourAnswersStageController < ApplicationController
   def show
+    @stages_questions_and_answers = [
+      CheckYourAnswers::Stage.new(
+        name: "destination",
+        title: "Destination",
+        link_path: stages_destination_path,
+        link_text: "destination",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :destination,
+            title: "Destination",
+            answer: "Saturn (core)"
+          )
+        ]
+      ),
+      CheckYourAnswers::Stage.new(
+        name: "dates",
+        title: "Dates",
+        link_path: stages_dates_path,
+        link_text: "dates",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :landing_date,
+            title: "Requested landing date",
+            answer: "10 August 2024"
+          ),
+          CheckYourAnswers::Question.new(
+            ref: :departure_date,
+            title: "Requested departure date",
+            answer: "18 August 2024"
+          )
+        ]
+      )
+    ]
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,7 +2,7 @@
 
 class SubmissionsController < ApplicationController
   def create
-    @submission_reference = "AFL-123-ABC"
+    @submission_reference = SubmissionsReferenceGenerator.generate
     render "successful_submission"
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SubmissionsController < ApplicationController
+  def create
+    @submission_reference = "AFL-123-ABC"
+    render "successful_submission"
+  end
+end

--- a/app/lib/submissions_reference_generator.rb
+++ b/app/lib/submissions_reference_generator.rb
@@ -1,5 +1,15 @@
 class SubmissionsReferenceGenerator
   def self.generate
-    "AFL-321-CBA"
+    "AFL-#{random_numbers}-#{random_letters}"
+  end
+
+  private_class_method
+
+  def self.random_numbers
+    3.times.map { Kernel.rand(1..9).to_s }.join
+  end
+
+  def self.random_letters
+    3.times.map { ("A".."Z").to_a.sample }.join
   end
 end

--- a/app/lib/submissions_reference_generator.rb
+++ b/app/lib/submissions_reference_generator.rb
@@ -1,0 +1,5 @@
+class SubmissionsReferenceGenerator
+  def self.generate
+    "AFL-321-CBA"
+  end
+end

--- a/app/models/check_your_answers/question.rb
+++ b/app/models/check_your_answers/question.rb
@@ -1,0 +1,8 @@
+module CheckYourAnswers
+  Question = Struct.new(
+    :ref,
+    :title,
+    :answer,
+    keyword_init: true
+  )
+end

--- a/app/models/check_your_answers/stage.rb
+++ b/app/models/check_your_answers/stage.rb
@@ -1,0 +1,10 @@
+module CheckYourAnswers
+  Stage = Struct.new(
+    :name,
+    :title,
+    :link_path,
+    :link_text,
+    :questions,
+    keyword_init: true
+  )
+end

--- a/app/views/stages/check_your_answers_stage/_question_and_answer.html.erb
+++ b/app/views/stages/check_your_answers_stage/_question_and_answer.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-summary-list__row question" data-question="<%= ref %>" >
+  <dt class="govuk-summary-list__key">
+    <%= title %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%= answer %>
+  </dd>
+</div>

--- a/app/views/stages/check_your_answers_stage/_summary_card.html.erb
+++ b/app/views/stages/check_your_answers_stage/_summary_card.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-summary-card stage" data-stage="<%= stage_name %>">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title"><%= stage_title %></h2>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action">
+        <a class="govuk-link" href="<%= link_path %>">
+          Change<span class="govuk-visually-hidden"> <%= link_text %></span>
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <% questions_and_answers.each do |question| %>
+        <%=
+          render(
+            partial: "question_and_answer",
+            locals: {
+              ref: question.ref,
+              title: question.title,
+              answer: question.answer
+            }
+          )
+        %>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/app/views/stages/check_your_answers_stage/show.erb
+++ b/app/views/stages/check_your_answers_stage/show.erb
@@ -23,12 +23,13 @@
 
             <h2 class="govuk-heading-m">Now send your landing application</h2>
             <p class="govuk-body">By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
-            <form action="/" method="post" novalidate>
-              <input type="hidden" name="answers-checked" value="true">
+
+            <%= form_tag(submissions_path) do -%>
               <button class="govuk-button" data-module="govuk-button">
                 Confirm and apply
               </button>
-            </form>
+            <% end -%>
+
           </div>
         </div>
       </article>

--- a/app/views/stages/check_your_answers_stage/show.erb
+++ b/app/views/stages/check_your_answers_stage/show.erb
@@ -6,64 +6,20 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
 
-            <div class="govuk-summary-card stage" data-stage="destination">
-              <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">Destination</h2>
-                <ul class="govuk-summary-card__actions">
-                  <li class="govuk-summary-card__action">
-                    <a class="govuk-link" href="/stages/destination">
-                      Change<span class="govuk-visually-hidden"> destination</span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-              <div class="govuk-summary-card__content">
-                <dl class="govuk-summary-list">
-                  <div class="govuk-summary-list__row question" data-question="destination" >
-                    <dt class="govuk-summary-list__key">
-                      Destination
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      Saturn (core)
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            </div>
-
-            <div class="govuk-summary-card stage" data-stage="dates">
-              <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">Dates</h2>
-                <ul class="govuk-summary-card__actions">
-                  <li class="govuk-summary-card__action">
-                    <a class="govuk-link" href="/stages/dates">
-                      Change<span class="govuk-visually-hidden"> dates</span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-              <div class="govuk-summary-card__content">
-                <dl class="govuk-summary-list">
-                  <div class="govuk-summary-list__row question" data-question="landing_date">
-                    <dt class="govuk-summary-list__key">
-                      Requested landing date
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      10 August 2024
-                    </dd>
-                  </div>
-
-                  <div class="govuk-summary-list__row question" data-question="departure_date">
-                    <dt class="govuk-summary-list__key">
-                      Requested departure date
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                      18 August 2024
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            </div>
+            <% @stages_questions_and_answers.each do |stage| %>
+               <%=
+                 render(
+                   partial: "summary_card",
+                   locals: {
+                     stage_name: stage.name,
+                     stage_title: stage.title,
+                     link_path: stage.link_path,
+                     link_text: stage.link_text,
+                     questions_and_answers: stage.questions
+                   }
+                 )
+               %>
+             <% end %>
 
             <h2 class="govuk-heading-m">Now send your landing application</h2>
             <p class="govuk-body">By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>

--- a/app/views/stages/check_your_answers_stage/show.erb
+++ b/app/views/stages/check_your_answers_stage/show.erb
@@ -3,6 +3,78 @@
     <div class="row">
       <article class="col">
         <h1 class="govuk-heading-xl">Check your answers</h1>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+
+            <div class="govuk-summary-card stage" data-stage="destination">
+              <div class="govuk-summary-card__title-wrapper">
+                <h2 class="govuk-summary-card__title">Destination</h2>
+                <ul class="govuk-summary-card__actions">
+                  <li class="govuk-summary-card__action">
+                    <a class="govuk-link" href="/stages/destination">
+                      Change<span class="govuk-visually-hidden"> destination</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div class="govuk-summary-card__content">
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row question" data-question="destination" >
+                    <dt class="govuk-summary-list__key">
+                      Destination
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      Saturn (core)
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+
+            <div class="govuk-summary-card stage" data-stage="dates">
+              <div class="govuk-summary-card__title-wrapper">
+                <h2 class="govuk-summary-card__title">Dates</h2>
+                <ul class="govuk-summary-card__actions">
+                  <li class="govuk-summary-card__action">
+                    <a class="govuk-link" href="/stages/dates">
+                      Change<span class="govuk-visually-hidden"> dates</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div class="govuk-summary-card__content">
+                <dl class="govuk-summary-list">
+                  <div class="govuk-summary-list__row question" data-question="landing_date">
+                    <dt class="govuk-summary-list__key">
+                      Requested landing date
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      10 August 2024
+                    </dd>
+                  </div>
+
+                  <div class="govuk-summary-list__row question" data-question="departure_date">
+                    <dt class="govuk-summary-list__key">
+                      Requested departure date
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      18 August 2024
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+
+            <h2 class="govuk-heading-m">Now send your landing application</h2>
+            <p class="govuk-body">By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
+            <form action="/" method="post" novalidate>
+              <input type="hidden" name="answers-checked" value="true">
+              <button class="govuk-button" data-module="govuk-button">
+                Confirm and apply
+              </button>
+            </form>
+          </div>
+        </div>
       </article>
     </row>
   </section>

--- a/app/views/submissions/successful_submission.html.erb
+++ b/app/views/submissions/successful_submission.html.erb
@@ -1,0 +1,22 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <div class="row">
+      <article class="col">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-panel govuk-panel--confirmation">
+              <h1 class="govuk-panel__title">
+                Application submitted
+              </h1>
+              <div class="govuk-panel__body">
+                Your reference number<br><strong><%= @submission_reference %></strong>
+              </div>
+            </div>
+
+            <p class="govuk-body">We aim to contact you with a decision within 3 working days</p>
+          </div>
+        </div>
+      </article>
+    </row>
+  </section>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     put :"check-your-answers", to: "check_your_answers_stage#update"
   end
 
+  resource :submissions, only: :create
+
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
   # hostname, redirect us to the canonical hostname with the path and query string present
   if ENV["CANONICAL_HOSTNAME"].present?

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe SubmissionsController do
+  describe "POST to :create" do
+    it "asks the submissions reference generator for a reference" do
+      allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(double)
+
+      post :create
+
+      expect(SubmissionsReferenceGenerator).to have_received(:generate)
+    end
+  end
+end

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -16,11 +16,11 @@ RSpec.feature "Stage 4: Check your answers" do
   end
 
   scenario "Change answers" do
-    # Given I have completed all the required stages
-    # And I am on the final 'Check your answers' stage
-    # When I choose to change an answer
-    # Then I see my saved answers
-    # And can advance through the stages back to 'Confirm your answers'
+    given_i_have_completed_all_the_required_stages
+    and_i_am_on_the_final_check_your_answers_stage
+    when_i_choose_to_change_an_answer
+    and_advance_through_the_stages_back_to_confirm_your_answers
+    then_i_see_my_edited_answer
   end
 
   def given_i_have_completed_all_the_required_stages
@@ -57,6 +57,26 @@ RSpec.feature "Stage 4: Check your answers" do
   def when_i_confirm_that_i_ve_reviewed_my_answers_and_wish_to_apply
     flunk("Not implemented")
     click_button("Confirm and apply")
+  end
+
+  def when_i_choose_to_change_an_answer
+    visit(stages_destination_path)
+    expect(page).to have_checked_field("Saturn (core)")
+
+    choose("Earth's moon")
+    click_button("Save and continue")
+  end
+
+  def and_advance_through_the_stages_back_to_confirm_your_answers
+    click_button("Save and continue")
+    click_button("Save and continue")
+    click_button("Save and continue")
+  end
+
+  def then_i_see_my_edited_answer
+    within ".stage[data-stage='destination']" do
+      expect(page).to have_content("Earth's moon")
+    end
   end
 
   # helpers

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Stage 4: Check your answers" do
   # helpers
 
   def stages
-    @stages = [
+    @stages ||= [
       CheckYourAnswers::Stage.new(
         name: "destination",
         title: "Destination",
@@ -76,6 +76,7 @@ RSpec.feature "Stage 4: Check your answers" do
           )
         ]
       ),
+
       CheckYourAnswers::Stage.new(
         name: "dates",
         title: "Dates",
@@ -91,6 +92,44 @@ RSpec.feature "Stage 4: Check your answers" do
             ref: :departure_date,
             title: "Requested departure date",
             answer: "18 August #{Date.today.year + 1}"
+          )
+        ]
+      ),
+
+      CheckYourAnswers::Stage.new(
+        name: "registration_identifier",
+        title: "Spacecraft Registration Identifier",
+        link_path: stages_registration_identifier_path,
+        link_text: "Registration ID",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :registration_id,
+            title: "Registration ID",
+            answer: "ABC123X"
+          )
+        ]
+      ),
+
+      CheckYourAnswers::Stage.new(
+        name: "personal_detals",
+        title: "Personal details",
+        link_path: stages_personal_details_path,
+        link_text: "personal details",
+        questions: [
+          CheckYourAnswers::Question.new(
+            ref: :fullname,
+            title: "Name",
+            answer: "Roger Smith"
+          ),
+          CheckYourAnswers::Question.new(
+            ref: :email,
+            title: "Email address",
+            answer: "roger@example.com"
+          ),
+          CheckYourAnswers::Question.new(
+            ref: :licence_id,
+            title: "Licence ID",
+            answer: "12345678"
           )
         ]
       )

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -61,36 +61,33 @@ RSpec.feature "Stage 4: Check your answers" do
 
   # helpers
 
-  Stage = Struct.new(:name, :title, :link_path, :link_text, :questions, keyword_init: true)
-  Question = Struct.new(:ref, :title, :answer, keyword_init: true)
-
   def stages
     @stages = [
-      Stage.new(
+      CheckYourAnswers::Stage.new(
         name: "destination",
         title: "Destination",
         link_path: stages_destination_path,
         link_text: "destination",
         questions: [
-          Question.new(
+          CheckYourAnswers::Question.new(
             ref: :destination,
             title: "Destination",
             answer: "Saturn (core)"
           )
         ]
       ),
-      Stage.new(
+      CheckYourAnswers::Stage.new(
         name: "dates",
         title: "Dates",
         link_path: stages_dates_path,
         link_text: "dates",
         questions: [
-          Question.new(
+          CheckYourAnswers::Question.new(
             ref: :landing_date,
             title: "Requested landing date",
             answer: "10 August #{Date.today.year + 1}"
           ),
-          Question.new(
+          CheckYourAnswers::Question.new(
             ref: :departure_date,
             title: "Requested departure date",
             answer: "18 August #{Date.today.year + 1}"

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -55,7 +55,6 @@ RSpec.feature "Stage 4: Check your answers" do
   end
 
   def when_i_confirm_that_i_ve_reviewed_my_answers_and_wish_to_apply
-    flunk("Not implemented")
     click_button("Confirm and apply")
   end
 
@@ -77,6 +76,16 @@ RSpec.feature "Stage 4: Check your answers" do
     within ".stage[data-stage='destination']" do
       expect(page).to have_content("Earth's moon")
     end
+  end
+
+  def then_i_receive_an_application_confirmation
+    within ".govuk-panel--confirmation" do
+      expect(page).to have_css(".govuk-panel__title", text: "Application submitted")
+      expect(page).to have_css(".govuk-panel__body", text: "Your reference number")
+      expect(page).to have_css(".govuk-panel__body", text: "AFL")
+    end
+
+    expect(page).to have_content("We aim to contact you with a decision within 3 working days")
   end
 
   # helpers
@@ -190,5 +199,4 @@ RSpec.feature "Stage 4: Check your answers" do
 
     click_button("Save and continue")
   end
-
 end

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -7,11 +7,12 @@
 
 RSpec.feature "Stage 4: Check your answers" do
   scenario "Confirm and apply" do
-    # Given I have completed all the required stages
-    # And I am on the final 'Check your answers' stage
-    # Then I see all the questions together with my answers
-    # When I confirm that I've reviewed my answers and wish to apply
-    # Then I receive an application confirmation
+    given_i_have_completed_all_the_required_stages
+    and_i_am_on_the_final_check_your_answers_stage
+    then_i_see_all_the_questions_together_with_my_answers
+
+    when_i_confirm_that_i_ve_reviewed_my_answers_and_wish_to_apply
+    then_i_receive_an_application_confirmation
   end
 
   scenario "Change answers" do
@@ -20,6 +21,118 @@ RSpec.feature "Stage 4: Check your answers" do
     # When I choose to change an answer
     # Then I see my saved answers
     # And can advance through the stages back to 'Confirm your answers'
+  end
+
+  def given_i_have_completed_all_the_required_stages
+    complete_destination_stage
+    complete_dates_stage
+    complete_registration_identifier_stage
+    complete_personal_details_stage
+  end
+
+  def and_i_am_on_the_final_check_your_answers_stage
+    visit(stages_check_your_answers_path)
+    expect(page).to have_content("Check your answers")
+  end
+
+  def then_i_see_all_the_questions_together_with_my_answers
+    stages.each do |stage|
+      within ".stage[data-stage='#{stage.name}']" do
+        expect(page).to have_css("h2", text: stage.title)
+
+        within ".govuk-summary-card__action" do
+          expect(page).to have_css("a[href='#{stage.link_path}']", text: "Change #{stage.link_text}")
+        end
+
+        stage.questions.each do |question|
+          within(".question[data-question='#{question.ref}']") do
+            within("dt") { expect(page).to have_content(question.title) }
+            within("dd") { expect(page).to have_content(question.answer) }
+          end
+        end
+      end
+    end
+  end
+
+  def when_i_confirm_that_i_ve_reviewed_my_answers_and_wish_to_apply
+    flunk("Not implemented")
+    click_button("Confirm and apply")
+  end
+
+  # helpers
+
+  Stage = Struct.new(:name, :title, :link_path, :link_text, :questions, keyword_init: true)
+  Question = Struct.new(:ref, :title, :answer, keyword_init: true)
+
+  def stages
+    @stages = [
+      Stage.new(
+        name: "destination",
+        title: "Destination",
+        link_path: stages_destination_path,
+        link_text: "destination",
+        questions: [
+          Question.new(
+            ref: :destination,
+            title: "Destination",
+            answer: "Saturn (core)"
+          )
+        ]
+      ),
+      Stage.new(
+        name: "dates",
+        title: "Dates",
+        link_path: stages_dates_path,
+        link_text: "dates",
+        questions: [
+          Question.new(
+            ref: :landing_date,
+            title: "Requested landing date",
+            answer: "10 August #{Date.today.year + 1}"
+          ),
+          Question.new(
+            ref: :departure_date,
+            title: "Requested departure date",
+            answer: "18 August #{Date.today.year + 1}"
+          )
+        ]
+      )
+    ]
+  end
+
+  def complete_destination_stage
+    visit(stages_destination_path)
+    choose("Saturn (core)")
+    click_button("Save and continue")
+  end
+
+  def complete_dates_stage
+    within ".landing" do
+      fill_in("Day", with: "10")
+      fill_in("Month", with: "08")
+      fill_in("Year", with: Date.today.year + 1)
+    end
+
+    within ".departure" do
+      fill_in("Day", with: "18")
+      fill_in("Month", with: "08")
+      fill_in("Year", with: Date.today.year + 1)
+    end
+
+    click_button("Save and continue")
+  end
+
+  def complete_registration_identifier_stage
+    fill_in("Registration ID", with: "ABC123X")
+    click_button("Save and continue")
+  end
+
+  def complete_personal_details_stage
+    fill_in("Full name", with: "Roger Smith")
+    fill_in("Email address", with: "roger@example.com")
+    fill_in("Licence ID", with: "12345678")
+
+    click_button("Save and continue")
   end
 
 end

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Feature: Stage 5: Check your answers
+#   So that I can review my answers and navigate to each stage to make an edit
+#   As a pilot applying to make a landing
+#   I want to review my answers and edit them if necessary
+
+RSpec.feature "Stage 4: Check your answers" do
+  scenario "Confirm and apply" do
+    # Given I have completed all the required stages
+    # And I am on the final 'Check your answers' stage
+    # Then I see all the questions together with my answers
+    # When I confirm that I've reviewed my answers and wish to apply
+    # Then I receive an application confirmation
+  end
+
+  scenario "Change answers" do
+    # Given I have completed all the required stages
+    # And I am on the final 'Check your answers' stage
+    # When I choose to change an answer
+    # Then I see my saved answers
+    # And can advance through the stages back to 'Confirm your answers'
+  end
+
+end

--- a/spec/lib/submissions_reference_generator_spec.rb
+++ b/spec/lib/submissions_reference_generator_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require_relative "../../app/lib/submissions_reference_generator"
+
+RSpec.describe SubmissionsReferenceGenerator do
+  let(:reference) { SubmissionsReferenceGenerator.generate }
+
+  describe "::generate" do
+    it "always applies an 'APL' prefix (Apply for Landing)" do
+      expect(reference).to match(/^AFL/)
+    end
+
+    it "includes a middle group of 3 numbers surrounded by hypens" do
+      expect(reference).to match(/-\d{3}-/)
+    end
+
+    it "ends with a group of 3 uppercase letters preceeded by a hypen" do
+      expect(reference).to match(/-[A-Z]{3}$/)
+    end
+  end
+end


### PR DESCRIPTION
In this PR we implement the final stage in the tasklist: check your answers.

The user reviews all the questions and the answers which they've given. Questions and their answers are grouped into one [Summary List](https://design-system.service.gov.uk/components/summary-list/) card per stage. The user can return to any section to edit their answers and can submit their application once they have checked their answers.

A submission [reference number](https://github.com/alphagov/govuk-design-system-backlog/issues/85) is shown in a notification [panel](https://design-system.service.gov.uk/components/panel/).

Note that at present nothing is persisted to a database. The application is saved to the user's session where it remains after submission.

In a future PR we will:

- save the application to a database
- add the submission reference to the persisted record
- clear the user's session so that they can create an additional landing application (they may be planning a tour, after all)

## Check your answers stage

![check_your_answers](https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/9efcd3fc-c0c0-468c-b4a5-32f7be043e3a)

## Application submitted "panel" with reference

<img width="761" alt="application_submitted_notification" src="https://github.com/dxw/dfsseta-apply-for-landing-ruby/assets/20245/ef4c385c-eb1f-484f-8d50-d98d97fd8f9a">

