### PR TITLE
Use dxw Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-      "config:base",
-      ":approveMajorUpdates",
-      ":automergeLinters",
-      ":automergePatch",
-      ":automergePr",
-      ":automergeRequireAllStatusChecks",
-      ":automergeTesters",
-      ":dependencyDashboard",
-      ":enablePreCommit",
-      ":combinePatchMinorReleases"
-    ],
-    "timezone": "Europe/London",
-    "platformAutomerge": true,
-    "automergeSchedule": [
-      "after 10am every weekday",
-      "before 4pm every weekday"
-    ],
-    "minimumReleaseAge": "3 days",
-    "packageRules": [
-      {
-        "matchDatasources": ["npm"],
-        "minimumReleaseAge": "5 days"
-      }
-    ],
-    "labels": ["dependencies"]
+  "extends": ["github>dxw/renovate-config"]
 }


### PR DESCRIPTION
We used this custom config because at the time we only had one dxw Renovate config and that wasn't very client-ready. We now have a default config that is more client ready and almost exactly the same as this (though we may later move to having more options with a more conservative default), so we can just extend from that