### PR TITLE
Configure Renovate to ignore Ruby on Rails

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>dxw/renovate-config:internal"]
+  "extends": ["github>dxw/renovate-config:internal"],
+  "ignoreDeps": ["rails"]
 }


### PR DESCRIPTION
The ignoreDeps configuration field allows you to define a list of dependency names to be ignored by Renovate [1].

Prevent Renovate from automerging updates for Ruby on Rails as it has a well defined upgrade process that must be followed [2].

[1]: https://docs.renovatebot.com/configuration-options/#ignoredeps
[2]: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html