### PR TITLE
Remove hardcoded date of Aug 8th 2024 - that's now in the past

### DIFF
--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -5,4 +5,4 @@
 
 set -e
 
-docker-compose -f docker-compose.ci.yml -p app build
+docker compose -f docker-compose.ci.yml -p app build

--- a/script/ci/test
+++ b/script/ci/test
@@ -6,7 +6,7 @@
 
 set -e
 
-docker-compose -f docker-compose.ci.yml \
+docker compose -f docker-compose.ci.yml \
                -p app \
                run --rm test \
                script/all/test "$@"

--- a/script/docker/bootstrap
+++ b/script/docker/bootstrap
@@ -23,5 +23,5 @@ for file_and_image in docker-compose.yml:web docker-compose.test.yml:test; do
 
   echo "==> Building $file_and_image Docker image..."
   # shellcheck disable=SC2086
-  docker-compose -f $file build $DOCKER_BUILD_ARGS $image
+  docker compose -f $file build $DOCKER_BUILD_ARGS $image
 done

--- a/script/docker/console
+++ b/script/docker/console
@@ -8,4 +8,4 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-docker-compose run --rm web bundle exec rails console
+docker compose run --rm web bundle exec rails console

--- a/script/docker/server
+++ b/script/docker/server
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/../.."
 
 # INFO: To enable debug prompts (with pry or byebug) we first start the process
 # in the background and then use attach to create an interactive prompt.
-docker-compose up --detach
+docker compose up --detach
 
 # TODO: Repace 'dfsseta-apply-for-landing' with application name
 docker attach dfsseta-apply-for-landing-ruby_web_1

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/../.."
 
 echo "==> Tearing down any previous application state..."
 for file in docker-compose.yml docker-compose.test.yml; do
-  docker-compose -f $file down --rmi local --volumes --remove-orphans
+  docker compose -f $file down --rmi local --volumes --remove-orphans
 done
 
 script/docker/bootstrap --no-docker-cache

--- a/script/docker/test
+++ b/script/docker/test
@@ -7,6 +7,6 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-docker-compose -f docker-compose.test.yml \
+docker compose -f docker-compose.test.yml \
                run --rm test \
                script/all/test "$@"

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DatesForm do
     end
 
     context "when landing_date is present" do
-      let(:form) { DatesForm.new(landing_date: Date.new(2024, 8, 4), departure_date: Date.today) }
+      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -39,7 +39,7 @@ RSpec.describe DatesForm do
     end
 
     context "when departure_date is present" do
-      let(:form) { DatesForm.new(landing_date: Date.today, departure_date: Date.new(2024, 8, 12)) }
+      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks) }
 
       it "should NOT flag an error" do
         form.valid?


### PR DESCRIPTION
Hardcoding future dates in unit tests is usually a bad idea as with the passage of time the date may move into the past and potentially break the test.

That was the case here. We now set the dates relative to 'now'.