### PR TITLE
Add validation to ensure that departure date does not exceed maximum permitted stay

### DIFF
--- a/app/forms/dates_form.rb
+++ b/app/forms/dates_form.rb
@@ -2,6 +2,7 @@ class DatesForm
   include ActiveModel::Model
 
   attr_accessor :landing_date, :departure_date
+  MAXIMUM_PERMITTED_STAY_IN_DAYS = 14
 
   def initialize(landing_date:, departure_date:)
     @landing_date = landing_date
@@ -15,12 +16,21 @@ class DatesForm
   validates_comparison_of :departure_date, greater_than: Date.today, message: "Departure date must be in the future"
 
   validate :ensure_departure_not_before_landing
+  validate :ensure_departure_date_within_maximum_permitted_stay
 
   def ensure_departure_not_before_landing
     return unless landing_date && departure_date
 
     if landing_date > departure_date
       errors.add(:base, "Landing date must be earlier than departure date")
+    end
+  end
+
+  def ensure_departure_date_within_maximum_permitted_stay
+    return unless landing_date && departure_date
+
+    if (departure_date - landing_date) > MAXIMUM_PERMITTED_STAY_IN_DAYS
+      errors.add(:departure_date, "Departure date must be within 14 days of landing date")
     end
   end
 end

--- a/app/views/stages/dates_stage/show.html.erb
+++ b/app/views/stages/dates_stage/show.html.erb
@@ -16,7 +16,7 @@
 
           <%= f.govuk_date_field :departure_date,
             legend: { text: 'Enter your requested departure date' },
-            hint: { text: 'For example, 15 4 2024' },
+            hint: { text: 'This must be within 14 days of your requested landing date' },
             class: ["departure"]
           %>
 

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -117,4 +117,45 @@ RSpec.describe DatesForm do
       end
     end
   end
+
+  describe "ensure departure date is no more than 14 days after landing date" do
+    let(:landing_date) { Date.today + 1.day }
+
+    context "when departure date is less than 14 days after landing date" do
+      let(:departure_date) { landing_date + 5.day }
+
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:departure_date)
+      end
+    end
+
+    context "when departure date is 14 days after landing date" do
+      let(:departure_date) { landing_date + 14.day }
+
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+
+      it "should NOT flag an error" do
+        form.valid?
+
+        expect(form.errors).to_not include(:departure_date)
+      end
+    end
+
+    context "when departure date is more than 14 days after landing date" do
+      let(:departure_date) { landing_date + 15.day }
+
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+
+      it "should flag an error" do
+        form.valid?
+
+        expect(form.errors).to include(:departure_date)
+        expect(form.errors.full_messages.join).to match("Departure date must be within 14 days of landing date")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a first pass at a simple iteration of this feature, with a maximum permitted stay of 14 days.

![Screenshot 2024-08-20 at 15 15 40](https://github.com/user-attachments/assets/7a6d6d48-2280-40e0-a082-09bb0ad42303)
