### PR TITLE
(8) Store "landable bodies" in db rather than hardcoded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "jsbundling-rails"
 gem "cssbundling-rails"
 gem "govuk_design_system_formbuilder"
 gem "terser"
+gem "seed-fu"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,9 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.3.1)
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     selenium-webdriver (4.23.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -435,6 +438,7 @@ DEPENDENCIES
   rollbar
   rspec-rails
   sass-rails (~> 6.0)
+  seed-fu
   selenium-webdriver
   simplecov
   standard

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: rake db:migrate && rake db:seed_fu

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,20 +3,15 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
-  LANDABLE_BODIES = [
-    OpenStruct.new(id: "f869e63d-3ce5-4480-b8ac-3eb0c266f659", name: "Mars"),
-    OpenStruct.new(id: "56f498b9-3b76-4ce8-9f3e-8a9ef20594f3", name: "Saturn (core)"),
-    OpenStruct.new(id: "11bced89-eb9c-4163-ad9e-c3cb89d6745c", name: "International Space Station (ESA)"),
-    OpenStruct.new(id: "bd41bc58-044b-4841-b159-219b091f68f2", name: "Tiangong space station"),
-    OpenStruct.new(id: "5db88724-cb68-431f-a7c6-6f08347458f4", name: "Earth's moon"),
-    OpenStruct.new(id: "21c97e41-ca50-4549-9892-36196d602a0f", name: "Pluto")
-  ].freeze
-
   def health_check
     render json: {
       rails: "OK",
       git_sha: ENV.fetch("CURRENT_GIT_SHA", "UNKNOWN"),
       built_at: ENV.fetch("TIME_OF_BUILD", "UNKNOWN")
     }, status: :ok
+  end
+
+  def landable_bodies
+    @landable_bodies = LandableBody.active
   end
 end

--- a/app/controllers/pilots_controller.rb
+++ b/app/controllers/pilots_controller.rb
@@ -2,6 +2,6 @@
 
 class PilotsController < ApplicationController
   def start
-    @landable_bodies = LANDABLE_BODIES
+    landable_bodies
   end
 end

--- a/app/controllers/stages/check_your_answers_stage_controller.rb
+++ b/app/controllers/stages/check_your_answers_stage_controller.rb
@@ -87,7 +87,7 @@ class Stages::CheckYourAnswersStageController < ApplicationController
   end
 
   def destination_answer
-    LANDABLE_BODIES
+    landable_bodies
       .find { |body| body.id == answers.find(:destination)&.dig("destination_id") }
       &.name
   end

--- a/app/controllers/stages/destination_stage_controller.rb
+++ b/app/controllers/stages/destination_stage_controller.rb
@@ -26,10 +26,6 @@ class Stages::DestinationStageController < ApplicationController
 
   private
 
-  def landable_bodies
-    @landable_bodies = LANDABLE_BODIES
-  end
-
   def answers
     @answers ||= AnswersRepository.new(session)
   end

--- a/app/models/landable_body.rb
+++ b/app/models/landable_body.rb
@@ -1,0 +1,2 @@
+class LandableBody < ApplicationRecord
+end

--- a/app/models/landable_body.rb
+++ b/app/models/landable_body.rb
@@ -1,2 +1,6 @@
 class LandableBody < ApplicationRecord
+  scope :active, -> {
+    where(active: true)
+      .order(name: :asc)
+  }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ Bundler.require(*Rails.groups)
 module ApplyForLandingRuby
   class Application < Rails::Application
     config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
       g.test_framework :rspec,
         fixtures: true,
         view_specs: false,

--- a/db/fixtures/01_landable_bodies.rb
+++ b/db/fixtures/01_landable_bodies.rb
@@ -1,0 +1,38 @@
+[
+  {
+    id: "f869e63d-3ce5-4480-b8ac-3eb0c266f659",
+    name: "Mars",
+    active: true
+  },
+  {
+    id: "56f498b9-3b76-4ce8-9f3e-8a9ef20594f3",
+    name: "Saturn (core)",
+    active: true
+  },
+  {
+    id: "11bced89-eb9c-4163-ad9e-c3cb89d6745c",
+    name: "International Space Station (ESA)",
+    active: true
+  },
+  {
+    id: "bd41bc58-044b-4841-b159-219b091f68f2",
+    name: "Tiangong space station",
+    active: true
+  },
+  {
+    id: "5db88724-cb68-431f-a7c6-6f08347458f4",
+    name: "Earth's moon",
+    active: true
+  },
+  {
+    id: "21c97e41-ca50-4549-9892-36196d602a0f",
+    name: "Pluto",
+    active: true
+  }
+].each do |body|
+  LandableBody.seed(:id) do |s|
+    s.id = body[:id]
+    s.name = body[:name]
+    s.active = body[:active]
+  end
+end

--- a/db/migrate/20240820111300_create_landable_bodies.rb
+++ b/db/migrate/20240820111300_create_landable_bodies.rb
@@ -1,0 +1,10 @@
+class CreateLandableBodies < ActiveRecord::Migration[7.2]
+  def change
+    create_table :landable_bodies, id: :uuid do |t|
+      t.text :name, null: false
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_20_111300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "landable_bodies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)

--- a/spec/factories/landable_bodies.rb
+++ b/spec/factories/landable_bodies.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :landable_body do
+    name { "Mercury" }
+  end
+end

--- a/spec/features/pilot/stage_0_start_page_understand_service_spec.rb
+++ b/spec/features/pilot/stage_0_start_page_understand_service_spec.rb
@@ -12,6 +12,11 @@ RSpec.feature "Stage 0: Start page - Pilot understands service before engaging" 
   #   And I should see what information I will need to provide
   #   When I choose to use the service
   #   Then I should find myself on the first stage of the service
+
+  before do
+    create_landable_bodies
+  end
+
   scenario "Stage 0: Start page - pilot reviews information about service" do
     visit "/"
     should_see_what_the_service_can_provide
@@ -70,15 +75,8 @@ RSpec.feature "Stage 0: Start page - Pilot understands service before engaging" 
   end
 
   def should_see_list_of_landable_bodies
-    [
-      "Mars",
-      "Saturn (core)",
-      "International Space Station (ESA)",
-      "Tiangong space station",
-      "Earth's moon",
-      "Pluto"
-    ].each do |landable_body|
-      expect(page).to have_content(landable_body)
+    LandableBody.where(active: true).each do |landable_body|
+      expect(page).to have_content(landable_body.name)
     end
   end
 

--- a/spec/features/pilot/stage_1_choose_destination_spec.rb
+++ b/spec/features/pilot/stage_1_choose_destination_spec.rb
@@ -16,6 +16,10 @@ RSpec.feature "Stage 1: Must choose destination" do
   #   And I proceed to the next stage
   #   Then I should find myself at the 'provide dates' stage
 
+  before do
+    create_landable_bodies
+  end
+
   scenario "Stage 1: Must choose destination" do
     given_i_am_at_the_choose_destination_stage
     when_i_fail_to_make_a_choice

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -5,7 +5,7 @@
 #   As a pilot applying to make a landing
 #   I want to review my answers and edit them if necessary
 
-RSpec.feature "Stage 4: Check your answers" do
+RSpec.feature "Stage 5: Check your answers" do
   before do
     create_landable_bodies
   end

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -6,6 +6,10 @@
 #   I want to review my answers and edit them if necessary
 
 RSpec.feature "Stage 4: Check your answers" do
+  before do
+    create_landable_bodies
+  end
+
   scenario "Confirm and apply" do
     given_i_have_completed_all_the_required_stages
     and_i_am_on_the_final_check_your_answers_stage

--- a/spec/models/landable_body_spec.rb
+++ b/spec/models/landable_body_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe LandableBody do
+  describe "::active" do
+    before do
+      FactoryBot.create(:landable_body, name: "Uranus", active: true)
+      FactoryBot.create(:landable_body, name: "Earth", active: true)
+      FactoryBot.create(:landable_body, name: "Neptune", active: false)
+    end
+
+    let(:bodies) { LandableBody.active.map(&:name) }
+
+    it "excludes records without the _active_ boolean flag" do
+      aggregate_failures do
+        expect(bodies).not_to include("Neptune")
+        expect(bodies.count).to eq(2)
+      end
+    end
+
+    it "orders the records by name" do
+      expect(bodies).to eq(["Earth", "Uranus"])
+    end
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
 Capybara.asset_host = "http://localhost:3000"
+
+def create_landable_bodies
+  FactoryBot.create(:landable_body, name: "Saturn (core)")
+  FactoryBot.create(:landable_body, name: "Earth's moon")
+end


### PR DESCRIPTION


In this PR we use the postgres database for the first time and introduce:

- migrations, using UUID as primary key
- the `seed-fu` gem for seeding data (run with `rake db:seed_fu`)
- the use of the `Procfile` for running `rake` tasks on each release to Heroku
- `FactoryBot` for creating db records for tests
