### PR TITLE
Fix 2 shell script linting issues

### DIFF
--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -28,7 +28,7 @@ set -e
 
 if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
   printf "\\nDatabase drop failed. Continue anyway? [y/N] "
-  read -r
+  read -r REPLY
 
   case $REPLY in
     y | Y)
@@ -50,7 +50,7 @@ set -e
 
 if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
   printf "\\nDatabase drop failed. Continue anyway? [y/N] "
-  read -r
+  read -r REPLY
 
   case $REPLY in
     y | Y)


### PR DESCRIPTION
When running:

`script/no-docker/test`

the `shellcheck` task was picking up two cases of:

```
SC3061 (warning): In POSIX sh, read without a variable is
                  undefined
```