### PR TITLE
(45) Store submitted application in db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,5 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov"
   gem "climate_control"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     tilt (2.3.0)
+    timecop (0.9.10)
     timeout (0.4.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -443,6 +444,7 @@ DEPENDENCIES
   simplecov
   standard
   terser
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,10 +3,10 @@
 class SubmissionsController < ApplicationController
   def create
     landing_application = SubmissionsProcessor
-      .new(reference: SubmissionsReferenceGenerator.generate, session: session)
+      .new(reference: ApplicationReferenceGenerator.generate, session: session)
       .call
 
-    @submission_reference = landing_application.application_reference
+    @application_reference = landing_application.application_reference
 
     render "successful_submission"
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,6 +3,11 @@
 class SubmissionsController < ApplicationController
   def create
     @submission_reference = SubmissionsReferenceGenerator.generate
+
+    SubmissionsProcessor
+      .new(reference: @submission_reference, session: session)
+      .call
+
     render "successful_submission"
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,11 +2,11 @@
 
 class SubmissionsController < ApplicationController
   def create
-    @submission_reference = SubmissionsReferenceGenerator.generate
-
-    SubmissionsProcessor
-      .new(reference: @submission_reference, session: session)
+    landing_application = SubmissionsProcessor
+      .new(reference: SubmissionsReferenceGenerator.generate, session: session)
       .call
+
+    @submission_reference = landing_application.application_reference
 
     render "successful_submission"
   end

--- a/app/lib/application_reference_generator.rb
+++ b/app/lib/application_reference_generator.rb
@@ -1,4 +1,4 @@
-class SubmissionsReferenceGenerator
+class ApplicationReferenceGenerator
   def self.generate
     "AFL-#{random_numbers}-#{random_letters}"
   end

--- a/app/lib/submissions_processor.rb
+++ b/app/lib/submissions_processor.rb
@@ -1,6 +1,12 @@
 class SubmissionsProcessor
-  def initialize(reference:, session:, repository_class: LandingApplication)
+  def initialize(
+    reference:,
+    session:,
+    repository_class: LandingApplication,
+    destination_finder: LandableBody
+  )
     @repository_class = repository_class
+    @destination_finder = destination_finder
     @reference = reference
     @session = session
   end
@@ -20,7 +26,11 @@ class SubmissionsProcessor
   private
 
   def destination
-    {destination: LandableBody.find(@session.dig("destination", "destination_id"))}
+    {
+      destination: @destination_finder.find(
+        @session.dig("destination", "destination_id")
+      )
+    }
   end
 
   def reference

--- a/app/lib/submissions_processor.rb
+++ b/app/lib/submissions_processor.rb
@@ -1,7 +1,38 @@
 class SubmissionsProcessor
-  def initialize(reference:, session:)
+  def initialize(reference:, session:, repository_class: LandingApplication)
+    @repository_class = repository_class
+    @reference = reference
+    @session = session
   end
 
   def call
+    @repository_class.create(
+      destination: destination,
+      pilot_name: @session.dig("personal_details", "fullname"),
+      pilot_email: @session.dig("personal_details", "email"),
+      pilot_licence_id: @session.dig("personal_details", "licence_id"),
+      spacecraft_registration_id: @session.dig("registration_identifier", "registration_id"),
+      landing_date: landing_date,
+      departure_date: departure_date,
+      application_reference: @reference,
+      application_submitted_at: Time.now,
+      application_decision: nil,
+      application_decision_made_at: nil,
+      permit_id: nil
+    )
+  end
+
+  private
+
+  def destination
+    LandableBody.find(@session.dig("destination", "destination_id"))
+  end
+
+  def landing_date
+    Date.parse(@session.dig("dates", "landing_date"))
+  end
+
+  def departure_date
+    Date.parse(@session.dig("dates", "departure_date"))
   end
 end

--- a/app/lib/submissions_processor.rb
+++ b/app/lib/submissions_processor.rb
@@ -1,0 +1,7 @@
+class SubmissionsProcessor
+  def initialize(reference:, session:)
+  end
+
+  def call
+  end
+end

--- a/app/lib/submissions_processor.rb
+++ b/app/lib/submissions_processor.rb
@@ -7,32 +7,59 @@ class SubmissionsProcessor
 
   def call
     @repository_class.create(
-      destination: destination,
-      pilot_name: @session.dig("personal_details", "fullname"),
-      pilot_email: @session.dig("personal_details", "email"),
-      pilot_licence_id: @session.dig("personal_details", "licence_id"),
-      spacecraft_registration_id: @session.dig("registration_identifier", "registration_id"),
-      landing_date: landing_date,
-      departure_date: departure_date,
-      application_reference: @reference,
-      application_submitted_at: Time.now,
-      application_decision: nil,
-      application_decision_made_at: nil,
-      permit_id: nil
+      destination
+        .merge(reference)
+        .merge(dates)
+        .merge(registration_identifier)
+        .merge(personal_details)
+        .merge(submitted_at)
+        .merge(blank_fields)
     )
   end
 
   private
 
   def destination
-    LandableBody.find(@session.dig("destination", "destination_id"))
+    {destination: LandableBody.find(@session.dig("destination", "destination_id"))}
   end
 
-  def landing_date
-    Date.parse(@session.dig("dates", "landing_date"))
+  def reference
+    {application_reference: @reference}
   end
 
-  def departure_date
-    Date.parse(@session.dig("dates", "departure_date"))
+  def dates
+    {
+      landing_date: Date.parse(@session.dig("dates", "landing_date")),
+      departure_date: Date.parse(@session.dig("dates", "departure_date"))
+    }
+  end
+
+  def registration_identifier
+    {
+      spacecraft_registration_id: @session.dig(
+        "registration_identifier",
+        "registration_id"
+      )
+    }
+  end
+
+  def personal_details
+    {
+      pilot_name: @session.dig("personal_details", "fullname"),
+      pilot_email: @session.dig("personal_details", "email"),
+      pilot_licence_id: @session.dig("personal_details", "licence_id")
+    }
+  end
+
+  def submitted_at
+    {application_submitted_at: Time.now}
+  end
+
+  def blank_fields
+    {
+      application_decision: nil,
+      application_decision_made_at: nil,
+      permit_id: nil
+    }
   end
 end

--- a/app/models/landable_body.rb
+++ b/app/models/landable_body.rb
@@ -1,4 +1,6 @@
 class LandableBody < ApplicationRecord
+  has_many :landing_applications, foreign_key: :destination_id
+
   scope :active, -> {
     where(active: true)
       .order(name: :asc)

--- a/app/models/landing_application.rb
+++ b/app/models/landing_application.rb
@@ -1,4 +1,3 @@
-class LandingApplication
-  def self.create(_attrs)
-  end
+class LandingApplication < ApplicationRecord
+  belongs_to :destination, foreign_key: :destination_id, class_name: "LandableBody"
 end

--- a/app/models/landing_application.rb
+++ b/app/models/landing_application.rb
@@ -1,0 +1,4 @@
+class LandingApplication
+  def self.create(_attrs)
+  end
+end

--- a/app/views/submissions/successful_submission.html.erb
+++ b/app/views/submissions/successful_submission.html.erb
@@ -9,7 +9,7 @@
                 Application submitted
               </h1>
               <div class="govuk-panel__body">
-                Your reference number<br><strong><%= @submission_reference %></strong>
+                Your reference number<br><strong><%= @application_reference %></strong>
               </div>
             </div>
 

--- a/db/migrate/20240821164300_create_landing_applications.rb
+++ b/db/migrate/20240821164300_create_landing_applications.rb
@@ -1,0 +1,24 @@
+class CreateLandingApplications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :landing_applications, id: :uuid do |t|
+      t.uuid :destination_id, null: false
+      t.string :pilot_email, null: false
+      t.string :pilot_name, null: false
+      t.string :pilot_licence_id, null: false
+      t.string :spacecraft_registration_id, null: false
+      t.date :landing_date, null: false
+      t.date :departure_date, null: false
+      t.string :application_reference, null: false
+      t.datetime :application_submitted_at, null: false
+
+      t.string :application_decision, null: true
+      t.datetime :application_decision_made_at, null: true
+      t.string :permit_id, null: true
+
+      t.timestamps
+    end
+
+    add_index :landing_applications, :destination_id
+    add_foreign_key :landing_applications, :landable_bodies, column: :destination_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_20_111300) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_21_164300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,4 +20,24 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_20_111300) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "landing_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "destination_id", null: false
+    t.string "pilot_email", null: false
+    t.string "pilot_name", null: false
+    t.string "pilot_licence_id", null: false
+    t.string "spacecraft_registration_id", null: false
+    t.date "landing_date", null: false
+    t.date "departure_date", null: false
+    t.string "application_reference", null: false
+    t.datetime "application_submitted_at", null: false
+    t.string "application_decision"
+    t.datetime "application_decision_made_at"
+    t.string "permit_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["destination_id"], name: "index_landing_applications_on_destination_id"
+  end
+
+  add_foreign_key "landing_applications", "landable_bodies", column: "destination_id"
 end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -3,6 +3,11 @@ require "rails_helper"
 RSpec.describe SubmissionsController do
   describe "POST to :create" do
     it "asks the submissions reference generator for a reference" do
+      processor = instance_double(SubmissionsProcessor)
+      allow(SubmissionsProcessor).to receive(:new).and_return(processor)
+
+      allow(processor).to receive(:call).and_return(double)
+
       allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(double)
 
       post :create

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe SubmissionsController do
   describe "POST to :create" do
+    let(:landing_application) { instance_double(LandingApplication, application_reference: double) }
+    let(:processor) { instance_double(SubmissionsProcessor) }
+
     it "asks the submissions reference generator for a reference" do
-      processor = instance_double(SubmissionsProcessor)
       allow(SubmissionsProcessor).to receive(:new).and_return(processor)
 
-      allow(processor).to receive(:call).and_return(double)
+      allow(processor).to receive(:call).and_return(landing_application)
 
       allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(double)
 
@@ -19,12 +21,11 @@ RSpec.describe SubmissionsController do
       reference = double("reference")
       allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(reference)
 
-      processor = instance_double(SubmissionsProcessor)
       expect(SubmissionsProcessor).to receive(:new)
         .with(reference: reference, session: request.session)
         .and_return(processor)
 
-      allow(processor).to receive(:call).and_return(double)
+      allow(processor).to receive(:call).and_return(landing_application)
 
       post :create
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -9,5 +9,21 @@ RSpec.describe SubmissionsController do
 
       expect(SubmissionsReferenceGenerator).to have_received(:generate)
     end
+
+    it "passes the reference and session to submissions processor" do
+      reference = double("reference")
+      allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(reference)
+
+      processor = instance_double(SubmissionsProcessor)
+      expect(SubmissionsProcessor).to receive(:new)
+        .with(reference: reference, session: request.session)
+        .and_return(processor)
+
+      allow(processor).to receive(:call).and_return(double)
+
+      post :create
+
+      expect(processor).to have_received(:call)
+    end
   end
 end

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe SubmissionsController do
 
       allow(processor).to receive(:call).and_return(landing_application)
 
-      allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(double)
+      allow(ApplicationReferenceGenerator).to receive(:generate).and_return(double)
 
       post :create
 
-      expect(SubmissionsReferenceGenerator).to have_received(:generate)
+      expect(ApplicationReferenceGenerator).to have_received(:generate)
     end
 
     it "passes the reference and session to submissions processor" do
       reference = double("reference")
-      allow(SubmissionsReferenceGenerator).to receive(:generate).and_return(reference)
+      allow(ApplicationReferenceGenerator).to receive(:generate).and_return(reference)
 
       expect(SubmissionsProcessor).to receive(:new)
         .with(reference: reference, session: request.session)

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe DatesForm do
 
   describe "ensure that both landing and departure dates are in the future" do
     let(:tomorrow) { Date.today + 1.day }
-    let(:yesterday) { Date.today(-1.day) }
+    let(:yesterday) { Date.today - 1.day }
 
     context "when landing date is in the past" do
       let(:form) { DatesForm.new(landing_date: yesterday, departure_date: tomorrow) }

--- a/spec/lib/application_reference_generator_spec.rb
+++ b/spec/lib/application_reference_generator_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
-require_relative "../../app/lib/submissions_reference_generator"
+require_relative "../../app/lib/application_reference_generator"
 
-RSpec.describe SubmissionsReferenceGenerator do
-  let(:reference) { SubmissionsReferenceGenerator.generate }
+RSpec.describe ApplicationReferenceGenerator do
+  let(:reference) { ApplicationReferenceGenerator.generate }
 
   describe "::generate" do
     it "always applies an 'APL' prefix (Apply for Landing)" do

--- a/spec/lib/submissions_processor_spec.rb
+++ b/spec/lib/submissions_processor_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe SubmissionsProcessor do
+  let(:time_now) { Time.now }
+
+  before do
+    Timecop.freeze(time_now)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe "#call" do
+    let(:repository_class) { class_double(LandingApplication) }
+    let(:reference) { "AFL-123-ABC" }
+
+    let(:destination) { FactoryBot.create(:landable_body, name: "Mars") }
+    let(:landing_date) { "#{Date.today.year + 1}-10-10" }
+    let(:departure_date) { "#{Date.today.year + 1}-10-17" }
+
+    let(:session) do
+      {
+        "destination" => {
+          "destination_id" => destination.id
+        },
+        "dates" => {
+          "landing_date" => landing_date,
+          "departure_date" => departure_date
+        },
+        "registration_identifier" => {
+          "registration_id" => "ABC123A"
+        },
+        "personal_details" => {
+          "fullname" => "Fred Daisy",
+          "email" => "fred@goo.com",
+          "licence_id" => "1233ABC00123"
+        }
+      }
+    end
+
+    it "creates a LandingApplication with the reference and data from session" do
+      allow(repository_class).to receive(:create).and_return(double)
+
+      SubmissionsProcessor.new(
+        session: session,
+        reference: reference,
+        repository_class: repository_class
+      ).call
+
+      expect(repository_class).to have_received(:create).with(
+        destination: destination,
+        pilot_name: "Fred Daisy",
+        pilot_email: "fred@goo.com",
+        pilot_licence_id: "1233ABC00123",
+        spacecraft_registration_id: "ABC123A",
+        landing_date: Date.parse(landing_date),
+        departure_date: Date.parse(departure_date),
+        application_reference: reference,
+        application_submitted_at: time_now,
+        application_decision: nil,
+        application_decision_made_at: nil,
+        permit_id: nil
+      )
+    end
+  end
+end

--- a/spec/lib/submissions_processor_spec.rb
+++ b/spec/lib/submissions_processor_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SubmissionsProcessor do
   end
 
   describe "#call" do
+    let(:destination_finder) { class_double(LandableBody) }
+
     let(:repository_class) { class_double(LandingApplication) }
     let(:reference) { "AFL-123-ABC" }
 
@@ -35,6 +37,20 @@ RSpec.describe SubmissionsProcessor do
           "licence_id" => "1233ABC00123"
         }
       }
+    end
+
+    it "retrieves the destination from LandingBody" do
+      allow(repository_class).to receive(:create).and_return(double)
+      allow(destination_finder).to receive(:find).and_return(double)
+
+      SubmissionsProcessor.new(
+        session: session,
+        reference: reference,
+        repository_class: repository_class,
+        destination_finder: destination_finder
+      ).call
+
+      expect(destination_finder).to have_received(:find).with(destination.id)
     end
 
     it "creates a LandingApplication with the reference and data from session" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/l4dTJ6lH/45-store-submitted-application-in-db)

In this PR we:

- introduce a `SubmissionsProcessor` with responsibility for creating a `LandingApplication` from the questionnaire data stored in the session and the submission (or "application") reference

- describe the interface between the `SubmissionsController` and the `SubmissionsProcessor` with a unit test in which all other collaborating classes are mocked (`SubmissionReferenceGenerator`, `LandingApplication`, `LandableBody`). We allow our unit testing to steer us towards dependency injection (passing `LandingApplication` and `LandableBody` into the constructor of the `SubmissionsProcessor`)

- convert our naive plain Ruby `LandingApplication` to an ActiveRecord class backed by the `landing_applications` database table