### PR TITLE
(45 pt 2) Clear answers from session on submission of application

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -8,6 +8,14 @@ class SubmissionsController < ApplicationController
 
     @application_reference = landing_application.application_reference
 
+    clear_application_from_session
+
     render "successful_submission"
+  end
+
+  private
+
+  def clear_application_from_session
+    AnswersRepository.new(session).clear_answers
   end
 end

--- a/app/repositories/answers_repository.rb
+++ b/app/repositories/answers_repository.rb
@@ -10,4 +10,10 @@ class AnswersRepository
   def find(stage_name)
     @session.dig(stage_name)
   end
+
+  def clear_answers
+    @session.keys
+      .filter { |key| !%w[session_id _csrf_token].include?(key) }
+      .each { |key| @session.delete(key) }
+  end
 end

--- a/app/views/submissions/successful_submission.html.erb
+++ b/app/views/submissions/successful_submission.html.erb
@@ -13,7 +13,16 @@
               </div>
             </div>
 
-            <p class="govuk-body">We aim to contact you with a decision within 3 working days</p>
+            <p class="govuk-body">
+              We aim to contact you with a decision within 3 working days</p>
+            </p>
+
+            <p class="govuk-body govuk-!-margin-top-9">
+              If you need to apply for another landing, you can now
+              <a href="/" class="govuk-link govuk-link--no-visited-state">
+                make another application
+              </a>
+            </p>
           </div>
         </div>
       </article>

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -31,5 +31,19 @@ RSpec.describe SubmissionsController do
 
       expect(processor).to have_received(:call)
     end
+
+    it "asks the AnswersRepository to clear the session to allow a fresh application" do
+      allow(SubmissionsProcessor).to receive(:new).and_return(processor)
+      allow(processor).to receive(:call).and_return(landing_application)
+      allow(ApplicationReferenceGenerator).to receive(:generate).and_return(double)
+
+      answers_repository = instance_double(AnswersRepository, clear_answers: double).tap do |ar|
+        allow(AnswersRepository).to receive(:new).and_return(ar)
+      end
+
+      post :create
+
+      expect(answers_repository).to have_received(:clear_answers)
+    end
   end
 end

--- a/spec/features/pilot/stage_5_check_your_answers_spec.rb
+++ b/spec/features/pilot/stage_5_check_your_answers_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "Stage 5: Check your answers" do
 
     when_i_confirm_that_i_ve_reviewed_my_answers_and_wish_to_apply
     then_i_receive_an_application_confirmation
+    and_i_can_start_a_new_blank_application
   end
 
   scenario "Change answers" do
@@ -92,7 +93,28 @@ RSpec.feature "Stage 5: Check your answers" do
     expect(page).to have_content("We aim to contact you with a decision within 3 working days")
   end
 
+  def and_i_can_start_a_new_blank_application
+    begin_a_new_application
+    expect_previous_application_to_have_been_cleared
+  end
+
   # helpers
+
+  def begin_a_new_application
+    click_link("make another application")
+    expect(current_path).to eq("/")
+    expect(page).to have_content(
+      "You can use this service to apply to land on " \
+        "one of several planets and astronomical bodies"
+    )
+    click_link("Start now")
+  end
+
+  def expect_previous_application_to_have_been_cleared
+    within(".destinations") do
+      expect(page).to_not have_checked_field("Saturn (core)")
+    end
+  end
 
   def stages
     @stages ||= [

--- a/spec/repositories/answers_repository_spec.rb
+++ b/spec/repositories/answers_repository_spec.rb
@@ -30,4 +30,37 @@ RSpec.describe AnswersRepository do
       expect(session).to have_received(:dig).with(:dates)
     end
   end
+
+  describe "#clear_session - to allow a fresh application for landing" do
+    let(:session) do
+      {
+        "session_id" => "123",
+        "_csrf_token" => "ABC",
+        "dates" => {},
+        "destination" => {"destination_id" => "ABC123"},
+        "another_question" => "another answer"
+      }
+    end
+
+    let(:repository) { AnswersRepository.new(session) }
+
+    it "clears data from keys NOT named 'session_id' or '_csrf_token'" do
+      allow(session).to receive(:delete)
+
+      repository.clear_answers
+
+      expect(session).to have_received(:delete).with("dates")
+      expect(session).to have_received(:delete).with("destination")
+      expect(session).to have_received(:delete).with("another_question")
+    end
+
+    it "leaves keys named 'session_id' or '_csrf_token'" do
+      allow(session).to receive(:delete)
+
+      repository.clear_answers
+
+      expect(session).to_not have_received(:delete).with("session_id")
+      expect(session).to_not have_received(:delete).with("_csrf_token")
+    end
+  end
 end


### PR DESCRIPTION
[Trello 45](https://trello.com/c/l4dTJ6lH/45-store-submitted-application-in-db)

Clear answers from session after submission.

This allows the user to make a fresh application.

We clear all the landing application data from the session -- that is all keys except those named:

- `session_id` and
- `_csrf_token`