### PR TITLE
Check landing departure dates do not fall on a UK bank holiday

### DIFF
--- a/app/controllers/stages/dates_stage_controller.rb
+++ b/app/controllers/stages/dates_stage_controller.rb
@@ -4,14 +4,16 @@ class Stages::DatesStageController < ApplicationController
   def show
     @dates = DatesForm.new(
       landing_date: saved_date("landing_date"),
-      departure_date: saved_date("departure_date")
+      departure_date: saved_date("departure_date"),
+      bank_holidays: BankHolidaysService.load
     )
   end
 
   def update
     @dates = DatesForm.new(
       landing_date: landing_date,
-      departure_date: departure_date
+      departure_date: departure_date,
+      bank_holidays: BankHolidaysService.load
     )
     if @dates.valid?
       answers.save(

--- a/app/forms/dates_form.rb
+++ b/app/forms/dates_form.rb
@@ -3,6 +3,7 @@ class DatesForm
 
   attr_accessor :landing_date, :departure_date
   MAXIMUM_PERMITTED_STAY_IN_DAYS = 14
+  BANK_HOLIDAYS = JSON.parse(File.read("#{Rails.root}/config/bank_holidays_uk.json")).dig('england-and-wales', 'events').map{ | event | event.fetch('date')}
 
   def initialize(landing_date:, departure_date:)
     @landing_date = landing_date
@@ -17,6 +18,7 @@ class DatesForm
 
   validate :ensure_departure_not_before_landing
   validate :ensure_departure_date_within_maximum_permitted_stay
+  validate :ensure_dates_do_not_fall_on_bank_holidays
 
   def ensure_departure_not_before_landing
     return unless landing_date && departure_date
@@ -31,6 +33,18 @@ class DatesForm
 
     if (departure_date - landing_date) > MAXIMUM_PERMITTED_STAY_IN_DAYS
       errors.add(:departure_date, "Departure date must be within 14 days of landing date")
+    end
+  end
+
+  def ensure_dates_do_not_fall_on_bank_holidays
+    return unless landing_date && departure_date
+
+    if BANK_HOLIDAYS.include?(landing_date.to_s)
+      errors.add(:landing_date, "Landing date must not fall on a bank holiday")
+    end
+
+    if BANK_HOLIDAYS.include?(departure_date.to_s)
+      errors.add(:departure_date, "Departure date must not fall on a bank holiday")
     end
   end
 end

--- a/app/forms/dates_form.rb
+++ b/app/forms/dates_form.rb
@@ -1,13 +1,13 @@
 class DatesForm
   include ActiveModel::Model
 
-  attr_accessor :landing_date, :departure_date
+  attr_accessor :landing_date, :departure_date, :bank_holidays
   MAXIMUM_PERMITTED_STAY_IN_DAYS = 14
-  BANK_HOLIDAYS = JSON.parse(File.read("#{Rails.root}/config/bank_holidays_uk.json")).dig('england-and-wales', 'events').map{ | event | event.fetch('date')}
 
-  def initialize(landing_date:, departure_date:)
+  def initialize(landing_date:, departure_date:, bank_holidays:)
     @landing_date = landing_date
     @departure_date = departure_date
+    @bank_holidays = bank_holidays
   end
 
   validates :landing_date, presence: {message: "Enter a landing date"}
@@ -39,11 +39,11 @@ class DatesForm
   def ensure_dates_do_not_fall_on_bank_holidays
     return unless landing_date && departure_date
 
-    if BANK_HOLIDAYS.include?(landing_date.to_s)
+    if bank_holidays.include?(landing_date.to_s)
       errors.add(:landing_date, "Landing date must not fall on a bank holiday")
     end
 
-    if BANK_HOLIDAYS.include?(departure_date.to_s)
+    if bank_holidays.include?(departure_date.to_s)
       errors.add(:departure_date, "Departure date must not fall on a bank holiday")
     end
   end

--- a/app/services/bank_holidays_service.rb
+++ b/app/services/bank_holidays_service.rb
@@ -1,0 +1,7 @@
+class BankHolidaysService
+  def self.load
+    JSON.parse(File.read("#{Rails.root}/config/bank_holidays_uk.json"))
+      .dig("england-and-wales", "events")
+      .map { |event| event.fetch("date") }
+  end
+end

--- a/config/bank_holidays_uk.json
+++ b/config/bank_holidays_uk.json
@@ -1,0 +1,1529 @@
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2026-04-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  },
+  "scotland": {
+    "division": "scotland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2018-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2018-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2019-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2019-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2020-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2020-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2021-01-04",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2021-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2022-01-04",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2022-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2023-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2023-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2024-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2024-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2025-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2025-12-01",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2026-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2026-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  },
+  "northern-ireland": {
+    "division": "northern-ireland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2018-03-19",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2018-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2019-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2019-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2020-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2020-07-13",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2021-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2021-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2022-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2022-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2023-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2023-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2024-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2024-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2025-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2025-07-14",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2026-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2026-04-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2026-07-13",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      }
+    ]
+  }
+}

--- a/spec/controllers/dates_stage_controller_spec.rb
+++ b/spec/controllers/dates_stage_controller_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Stages::DatesStageController do
+  describe "GET to :show" do
+    mock_bank_holidays = ["2026-02-01", "2026-02-02", "2026-02-03"]
+
+    it "calls DateForm.new with a list of bank holidays" do
+      expect(BankHolidaysService).to receive(:load).and_return(mock_bank_holidays)
+      allow(DatesForm).to receive(:new)
+
+      get :show
+
+      expect(DatesForm).to have_received(:new).with(departure_date: nil, landing_date: nil, bank_holidays: mock_bank_holidays)
+    end
+  end
+end

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DatesForm do
   describe "it validates presence of landing_date" do
     context "when landing_date is missing" do
-      let(:form) { DatesForm.new(landing_date: nil, departure_date: Date.today) }
+      let(:form) { DatesForm.new(landing_date: nil, departure_date: Date.today, bank_holidays: []) }
 
       it "should flag an error" do
         form.valid?
@@ -14,7 +14,7 @@ RSpec.describe DatesForm do
     end
 
     context "when landing_date is present" do
-      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks) }
+      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -26,7 +26,7 @@ RSpec.describe DatesForm do
 
   describe "it validates presence of departure_date" do
     context "when departure_date is missing" do
-      let(:form) { DatesForm.new(landing_date: Date.today, departure_date: nil) }
+      let(:form) { DatesForm.new(landing_date: Date.today, departure_date: nil, bank_holidays: []) }
 
       it "should flag an error" do
         form.valid?
@@ -39,7 +39,7 @@ RSpec.describe DatesForm do
     end
 
     context "when departure_date is present" do
-      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks) }
+      let(:form) { DatesForm.new(landing_date: Date.today + 1.week, departure_date: Date.today + 2.weeks, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -54,7 +54,7 @@ RSpec.describe DatesForm do
     let(:day_after_tomorrow) { Date.today + 2.days }
 
     context "when departure date IS before landing date" do
-      let(:form) { DatesForm.new(landing_date: day_after_tomorrow, departure_date: tomorrow) }
+      let(:form) { DatesForm.new(landing_date: day_after_tomorrow, departure_date: tomorrow, bank_holidays: ["2025-11-01"]) }
 
       it "should flag an error" do
         form.valid?
@@ -67,7 +67,7 @@ RSpec.describe DatesForm do
     end
 
     context "when departure date is after landing date" do
-      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: day_after_tomorrow) }
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: day_after_tomorrow, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -77,7 +77,7 @@ RSpec.describe DatesForm do
     end
 
     context "when departure date is the same as landing date" do
-      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: tomorrow) }
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: tomorrow, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -92,7 +92,7 @@ RSpec.describe DatesForm do
     let(:yesterday) { Date.today - 1.day }
 
     context "when landing date is in the past" do
-      let(:form) { DatesForm.new(landing_date: yesterday, departure_date: tomorrow) }
+      let(:form) { DatesForm.new(landing_date: yesterday, departure_date: tomorrow, bank_holidays: []) }
 
       it "should flag an error" do
         form.valid?
@@ -105,7 +105,7 @@ RSpec.describe DatesForm do
     end
 
     context "when departure date is in the past" do
-      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: yesterday) }
+      let(:form) { DatesForm.new(landing_date: tomorrow, departure_date: yesterday, bank_holidays: []) }
 
       it "should flag an error" do
         form.valid?
@@ -124,7 +124,7 @@ RSpec.describe DatesForm do
     context "when departure date is less than 14 days after landing date" do
       let(:departure_date) { landing_date + 5.day }
 
-      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -136,7 +136,7 @@ RSpec.describe DatesForm do
     context "when departure date is 14 days after landing date" do
       let(:departure_date) { landing_date + 14.day }
 
-      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date, bank_holidays: []) }
 
       it "should NOT flag an error" do
         form.valid?
@@ -148,7 +148,7 @@ RSpec.describe DatesForm do
     context "when departure date is more than 14 days after landing date" do
       let(:departure_date) { landing_date + 15.day }
 
-      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date, bank_holidays: []) }
 
       it "should flag an error" do
         form.valid?
@@ -161,10 +161,10 @@ RSpec.describe DatesForm do
 
   describe "ensure landing and departure dates do not fall on bank holidays" do
     context "when they fall on bank holidays" do
-      let(:landing_date) { Date.new(Date.today.year + 1, 12, 25) }
-      let(:departure_date) { Date.new(Date.today.year + 1, 12, 26) }
+      let(:landing_date) { Date.new(Date.today.year + 1, 1, 10) }
+      let(:departure_date) { Date.new(Date.today.year + 1, 1, 15) }
 
-      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date, bank_holidays: [landing_date.to_s, departure_date.to_s]) }
 
       it "should flag an error" do
         form.valid?

--- a/spec/forms/dates_form_spec.rb
+++ b/spec/forms/dates_form_spec.rb
@@ -158,4 +158,21 @@ RSpec.describe DatesForm do
       end
     end
   end
+
+  describe "ensure landing and departure dates do not fall on bank holidays" do
+    context "when they fall on bank holidays" do
+      let(:landing_date) { Date.new(Date.today.year + 1, 12, 25) }
+      let(:departure_date) { Date.new(Date.today.year + 1, 12, 26) }
+
+      let(:form) { DatesForm.new(landing_date: landing_date, departure_date: departure_date) }
+
+      it "should flag an error" do
+        form.valid?
+
+        expect(form.errors).to include(:departure_date, :landing_date)
+        expect(form.errors.full_messages.join).to match("Landing date must not fall on a bank holiday")
+        expect(form.errors.full_messages.join).to match("Departure date must not fall on a bank holiday")
+      end
+    end
+  end
 end

--- a/spec/services/bank_holidays_service_spec.rb
+++ b/spec/services/bank_holidays_service_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe BankHolidaysService do
+  describe "load" do
+    before do
+      allow(File).to receive(:read).and_return(json)
+      allow(JSON).to receive(:parse).and_return(JSON.parse(json))
+    end
+
+    let(:json) do
+      <<~JSON
+        {
+          "england-and-wales": {
+            "division": "england-and-wales",
+              "events": []
+          }
+        }
+      JSON
+    end
+
+    it "reads the JSON file containing the UK holidays" do
+      BankHolidaysService.load
+
+      expect(File).to have_received(:read)
+        .with("#{Rails.root}/config/bank_holidays_uk.json")
+    end
+
+    it "parses the JSON contained in this file" do
+      BankHolidaysService.load
+
+      expect(JSON).to have_received(:parse).with(json)
+    end
+  end
+end


### PR DESCRIPTION
Ensures the above with the addition of a bank holiday service to return BHs for England and Wales.

![Screenshot 2024-08-23 at 14 43 16](https://github.com/user-attachments/assets/6cc9d13f-95b6-4cee-9e63-e75b86626c9e)
