### PR TITLE
Trigger E2E tests using 'repository-dispatch'

### DIFF
--- a/.github/workflows/trigger_e2e_tests.yml
+++ b/.github/workflows/trigger_e2e_tests.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  triggerE2eTests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger E2E tests in separate repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: dxw/dfsseta-apply-for-landing-e2e
+          event-type: trigger-e2e-tests
+          client-payload:
+            '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/README.md
+++ b/README.md
@@ -64,3 +64,51 @@ For bundling JS and CSS you will need:
 
 The local development application is then run using `bin/dev` which asks
 `foreman` to run the app's `Procfile`.
+
+## Tests
+
+### Local unit and integration tests
+
+These tests (Rspec and Capybara) can be run with:
+
+```sh
+bundle exec rspec
+```
+or using either the dockerised or undockerised version of the supplied comprehensive
+test script which includes updates, gem auditing, linting etc, e.g.
+
+```sh
+./script/no-docker/test
+```
+
+### End-to-end (E2E) tests
+
+Our end-to-end tests live in a separate repo [`dxw/dfsseta-apply-for-landing-e2e`][]
+and are written using Playwright.
+
+They have their own repo as we intend to use the same set of tests to exercise each
+implementation of the Apply For Landing model application. i.e. to run against the
+Ruby implementation (here), the .NET version, the Node version etc.
+
+See that repo for more info.
+
+Each merge to the `main` branch triggers the E2E test suite, which run against
+the application [deployed to Heroku][]
+
+
+## Deployment
+
+The application is [deployed to Heroku][] on each merge to `main` by way of a [GitHub
+Action][].
+
+
+[`dxw/dfsseta-apply-for-landing-e2e`]:
+https://github.com/dxw/dfsseta-apply-for-landing-e2e
+
+[GitHub Action]:
+https://github.com/dxw/dfsseta-apply-for-landing-ruby/blob/main/.github/workflows/heroku-deployment.yml
+
+[deployed to Heroku]:
+https://apply-for-landing-ruby-4492c2b72668.herokuapp.com/
+
+


### PR DESCRIPTION
See [GitHub docs][] and [Github Action][].

We send a trigger for an action called `trigger-e2e-tests`
to our E2E repo (`dxw/dfsseta-apply-for-landing-e2e`).

This is triggered on each merge to the `main` branch.

Access to the E2E repo is authorised with a ["fine-grained
personal access token"][] (PAT)

[GitHub docs]:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch

[Github Action]:
https://github.com/marketplace/actions/repository-dispatch

["fine-grained personal access token"]:
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token

### Action triggered on 'main' repo
<img width="923" alt="trigger_action_from_main_repo" src="https://github.com/user-attachments/assets/9cd270f8-536c-4a79-844e-66b6157fdb30">



### Actions received / triggered on E2E repo
<img width="1080" alt="trigger_playwright_action" src="https://github.com/user-attachments/assets/8807bfc6-1bb9-49bb-a0c4-978731503cac">

