### PR TITLE
Officer views list of landing applications

### DIFF
--- a/app/controllers/officer/landing_applications_controller.rb
+++ b/app/controllers/officer/landing_applications_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Officer::LandingApplicationsController < ApplicationController
+  def index
+    @landing_applications = LandingApplication
+      .includes(:destination)
+      .order(application_submitted_at: :desc)
+  end
+end

--- a/app/views/officer/landing_applications/index.html.erb
+++ b/app/views/officer/landing_applications/index.html.erb
@@ -1,0 +1,39 @@
+<main class="govuk-main-wrapper">
+  <section class="container">
+    <h1 class='govuk-heading-l'>Landing applications</h1>
+
+    <%= govuk_table do |table|
+      table.with_caption(size: 'm', text: 'Applications to assess')
+      
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: 'Pilot name')
+          row.with_cell(text: 'Pilot email')
+          row.with_cell(text: 'Destination')
+          row.with_cell(text: 'Landing date')
+          row.with_cell(text: 'Departure date')
+          row.with_cell(text: 'Application date')
+          row.with_cell(text: 'Decision')      
+        end
+      end
+
+      table.with_body do |body|
+        @landing_applications.each do |application|
+          body.with_row do |row|
+            row.with_cell(text: application.pilot_name)
+            row.with_cell(text: application.pilot_email)
+            row.with_cell(text: application.destination.name)
+            row.with_cell(text: application.landing_date)
+            row.with_cell(text: application.departure_date)
+            row.with_cell(text: application.application_submitted_at.to_date, html_attributes: { id: "submission-date" })
+            row.with_cell(text: '')
+          end
+        end
+      end
+
+    end
+      
+      %>
+
+  </section>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,10 @@ Rails.application.routes.draw do
     put :"check-your-answers", to: "check_your_answers_stage#update"
   end
 
+  namespace :officer do
+    get :"landing-applications", to: "landing_applications#index"
+  end
+
   resource :submissions, only: :create
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/spec/controllers/landing_applications_controller_spec.rb
+++ b/spec/controllers/landing_applications_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Officer::LandingApplicationsController do
+  describe "GET to :index" do
+    it "retrieves the landing applications, newest first, with destinations loaded" do
+      ar_query = double("query", order: double)
+      allow(LandingApplication).to receive(:includes).and_return(ar_query)
+
+      get :index
+
+      expect(LandingApplication).to have_received(:includes).with(:destination)
+      expect(ar_query).to have_received(:order).with(application_submitted_at: :desc)
+    end
+  end
+end

--- a/spec/factories/landing_applications.rb
+++ b/spec/factories/landing_applications.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :landing_application do
+    association(:destination, factory: :landable_body)
+    pilot_email { "alan@nasa.org.uk" }
+    pilot_name { "Alan Oliver" }
+    pilot_licence_id { "1233ABC00123" }
+    spacecraft_registration_id { "ABC123A" }
+    landing_date { Date.tomorrow }
+    departure_date { Date.tomorrow + 3 }
+    application_reference { ApplicationReferenceGenerator.generate }
+    application_submitted_at { Time.current }
+  end
+end

--- a/spec/features/officer/view_landing_applications_spec.rb
+++ b/spec/features/officer/view_landing_applications_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Feature: Officer views list of landing applications
+#   So that I can identify and prioritise my work assessing landing applications
+#   As a DfSSETA officer
+#   I want to see a list of landing applications
+
+RSpec.feature "Officer views list of landing applications" do
+  # Scenario: Officer views list of landing applications
+  #   Given there are existing applications in the database
+  #   When I go to the landing applications page
+  #   Then I should see a list of applications
+
+  before do
+    create_applications
+  end
+
+  scenario "Officer views list of landing applications" do
+    visit officer_landing_applications_path
+    should_see_list_of_applications
+    should_see_applications_ordered_by_date_submitted
+  end
+
+  def should_see_applications_ordered_by_date_submitted
+    expect(
+      find_all("#submission-date").map { |ele| ele.text }
+    ).to eq(
+      ["2024-01-01",
+        "2023-01-01",
+        "2022-01-01"]
+    )
+  end
+
+  def should_see_list_of_applications
+    LandingApplication.includes(:destination).each do |landing_application|
+      expect(page).to have_content(landing_application.pilot_name)
+      expect(page).to have_content(landing_application.application_submitted_at.to_date)
+      expect(page).to have_content(landing_application.pilot_email)
+      expect(page).to have_content(landing_application.destination.name)
+      expect(page).to have_content(landing_application.landing_date)
+      expect(page).to have_content(landing_application.departure_date)
+    end
+  end
+
+  def create_applications
+    FactoryBot.create(:landing_application, pilot_name: "Jane", application_submitted_at: Time.new(2022))
+    FactoryBot.create(:landing_application, pilot_name: "Fred", application_submitted_at: Time.new(2023))
+    FactoryBot.create(:landing_application, pilot_name: "Sam", application_submitted_at: Time.new(2024))
+  end
+end


### PR DESCRIPTION
Adds a new route, `offier/landing-applications`, for DfSSETA officers to view all landing applications, with the most recently submitted applications first.

![Screenshot 2024-09-02 at 12 09 08](https://github.com/user-attachments/assets/518ce15a-dfc1-477e-bc36-e2bac28958f0)