### PR TITLE
(53) Apply Rails' strict_loading to all models

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,14 @@ module ApplyForLandingRuby
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Alert if lazily loading records in order to guard against N+1 queries.
+    # (we disable strict_loading if we're in a console session)
+    # Individual environments specify whether to raise StrictLoadingViolationError:
+    #   - raises in development and test
+    #   - logs in production
+    config.active_record.strict_loading_by_default = !["rails_console", "bin/rails"]
+      .include?($PROGRAM_NAME)
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,10 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Raises StrictLoadingViolationError if lazily loading records
+  # in order to guard against N+1 queries
+  config.active_record.action_on_strict_loading_violation = :raise
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Logs (rather than raises) if lazily loading records
+  # in order to warn of N+1 queries.
+  # In other environments we raise StrictLoadingViolationError
+  config.active_record.action_on_strict_loading_violation = :log
+
   # See https://github.com/rails/rails/issues/29893
   # This only allows hosts the application can trust when using `url_for` and related helpers
   if ENV["CANONICAL_HOSTNAME"].present?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,6 +66,10 @@ Rails.application.configure do
   # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
   config.assets.css_compressor = nil
 
+  # Raises StrictLoadingViolationError if lazily loading records
+  # in order to guard against N+1 queries
+  config.active_record.action_on_strict_loading_violation = :raise
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true


### PR DESCRIPTION
In order to guard against N+1 queries we use the Rails ["strict_loading" controls][] to alert if we lazily load records.

Individual environments specify whether to raise `StrictLoadingViolationError` when a failure to [eager load][] is detected:

  - *raises* in development and test
  - *logs* in production

We disable strict_loading if we're in a console session as this would otherwise be inconvenient when exploring data.

For example if we write a test assertion which attempts to lazily load an associated model we'll see an error like:

```
1) Officer views list of landing applications Officer views list of landing applications
     Failure/Error: expect(page).to have_content(landing_application.destination.name)

     ActiveRecord::StrictLoadingViolationError:
       `LandingApplication` is marked for strict_loading. 
       The LandableBody association named `:destination` cannot be lazily loaded.
```

["strict_loading" controls]:
https://edgeguides.rubyonrails.org/configuring.html#config-active-record-action-on-strict-loading-violation

[eager load]:
https://guides.rubyonrails.org/active_record_querying.html#eager-load