### PR TITLE
(68) Setup OpenAPI development harness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem "cssbundling-rails"
 gem "govuk_design_system_formbuilder"
 gem "govuk-components"
 gem "terser"
+gem "rswag-api"
+gem "rswag-ui"
 gem "seed-fu"
 
 group :development do
@@ -43,6 +45,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
   gem "rspec-rails"
+  gem "rswag-specs"
   gem "standard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.7.2)
+    json-schema (4.3.1)
+      addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -312,6 +314,17 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.2)
+    rswag-api (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      railties (>= 5.2, < 8.0)
+    rswag-specs (2.14.0)
+      activesupport (>= 5.2, < 8.0)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 5.2, < 8.0)
+      rspec-core (>= 2.14)
+    rswag-ui (2.14.0)
+      actionpack (>= 5.2, < 8.0)
+      railties (>= 5.2, < 8.0)
     rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -448,6 +461,9 @@ DEPENDENCIES
   rails_layout
   rollbar
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   sass-rails (~> 6.0)
   seed-fu
   selenium-webdriver

--- a/app/controllers/api/landing_applications_controller.rb
+++ b/app/controllers/api/landing_applications_controller.rb
@@ -1,0 +1,5 @@
+class Api::LandingApplicationsController < ApplicationController
+  def index
+    render json: {}
+  end
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,13 @@
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + "/swagger"
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,15 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,10 @@ Rails.application.routes.draw do
     get :"landing-applications", to: "landing_applications#index"
   end
 
+  namespace :api do
+    get :"landing-applications", to: "landing_applications#index"
+  end
+
   resource :submissions, only: :create
 
   # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
+
   get "health_check" => "application#health_check"
   root to: "pilots#start"
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,7 +15,7 @@
 # http://edgeguides.rubyonrails.org/security.html#custom-credentials
 
 development:
-  domain_name: example.com
+  domain_name: <%= ENV["DOMAIN_NAME"] %>
   secret_key_base: very_long_random_string
 
 test:

--- a/spec/api/landing_applications_spec.rb
+++ b/spec/api/landing_applications_spec.rb
@@ -1,0 +1,19 @@
+require "swagger_helper"
+
+RSpec.describe "API: landing-applications", type: :request do
+  describe "GET /landing-applications endpoint" do
+    path "/api/landing-applications" do
+      get "Retrieves a list of landing applications" do
+        tags "Landing applications"
+        produces "application/json"
+
+        response "200", "success" do
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data).to eq({})
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you"re using the rswag-api to serve API descriptions, you"ll need
+  # to ensure that it"s configured to serve Swagger from the same folder
+  config.openapi_root = Rails.root.join("swagger").to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the "rswag:specs:swaggerize" rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe "...", openapi_spec: "v2/swagger.json"
+  config.openapi_specs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "API V1",
+        version: "v1"
+      },
+      paths: {},
+      servers: [
+        {
+          url: "https://{defaultHost}",
+          variables: {
+            defaultHost: {
+              default: ENV.fetch("HOSTNAME")
+            }
+          }
+        },
+        {
+          url: "http://{defaultHost}",
+          variables: {
+            defaultHost: {
+              default: "localhost:3000"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running "rswag:specs:swaggerize".
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ":json" and ":yaml".
+  config.openapi_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,23 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/landing-applications":
+    get:
+      summary: Retrieves a list of landing applications
+      tags:
+      - Landing applications
+      responses:
+        '200':
+          description: success
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost
+- url: http://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost:3000


### PR DESCRIPTION
[Trello 68](https://trello.com/c/Wr5T6OLU/68-choose-openapi-tooling)

We install and configure RSwag libraries for TDD with OpenAPI.

With these libraries we'll

- write integration tests to describe our API endpoints

- generate OpenAPI specs

- expose these OpenAPI specs at `/api-docs/index.html` to
  assist consumers of the API

NOTE

There's a manual step which needs to be completed after
changing the integration tests in order to update the
OpenAPI specs:

```
rake rswag:specs:swaggerize
```

This rewrites the OpenAPI spec, in YAML format at:

```
swagger/v1/swagger.yaml
```

### Swagger UI available at `/api-docs/index.html`

![swagger_ui](https://github.com/user-attachments/assets/b136d1bb-feb9-4151-8840-a7cb4a83d6c5)
