### PR TITLE
(69) Expose list of landing applications

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,4 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/dfsseta-apply-for-landing-test
+HOSTNAME=localhost

--- a/README.md
+++ b/README.md
@@ -71,14 +71,42 @@ The local development application is then run using `bin/dev` which asks
 
 ### Local unit and integration tests
 
-These tests (Rspec and Capybara) can be run with:
+#### Fast feedback loop
+
+These tests (Rspec and Capybara) can be run at maximum speed with:
 
 ```sh
 bundle exec rspec
 ```
 
-or using either the dockerised or undockerised version of the supplied
-comprehensive test script which includes updates, gem auditing, linting etc,
+To run individual API specs with auto-generation of the OpenAPI spec, you need
+to specify the use the Rswag "formatter" e.g:
+
+```sh
+bundle exec rspec  --format Rswag::Specs::SwaggerFormatter \
+       spec/api/landing_applications_spec.rb
+```
+
+### Full pre-commit checks
+
+Before committing you should run our complete set of checks and tests.
+
+This is especially important if working on the API code as we're using the Rswag
+tooling to generate our OpenAPI spec from the integration tests in `spec/api`.
+
+Choose from either the dockerised or undockerised version of the supplied
+comprehensive test script which includes:
+
+- formatting files with `prettier`
+- checking scripts with `shellcheck`
+- linting Ruby files with `standardrb`
+- linting JS with `eslint`
+- linting CSS with `stylelint`
+- running automated test suite with `rspec`
+- running API specs and generating OpenAPI spec via the
+  `rswag_api_tests_with_docs` `rake` task
+- analysing vulnerabilities in Ruby gems with `brakeman`
+
 e.g.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ These tests (Rspec and Capybara) can be run with:
 ```sh
 bundle exec rspec
 ```
-or using either the dockerised or undockerised version of the supplied comprehensive
-test script which includes updates, gem auditing, linting etc, e.g.
+
+or using either the dockerised or undockerised version of the supplied
+comprehensive test script which includes updates, gem auditing, linting etc,
+e.g.
 
 ```sh
 ./script/no-docker/test
@@ -85,37 +87,32 @@ test script which includes updates, gem auditing, linting etc, e.g.
 
 ### End-to-end (E2E) tests
 
-Our end-to-end tests live in a separate repo [`dxw/dfsseta-apply-for-landing-e2e`][]
-and are written using Playwright.
+Our end-to-end tests live in a separate repo
+[`dxw/dfsseta-apply-for-landing-e2e`][] and are written using Playwright.
 
-They have their own repo as we intend to use the same set of tests to exercise each
-implementation of the Apply For Landing model application. i.e. to run against the
-Ruby implementation (here), the .NET version, the Node version etc.
+They have their own repo as we intend to use the same set of tests to exercise
+each implementation of the Apply For Landing model application. i.e. to run
+against the Ruby implementation (here), the .NET version, the Node version etc.
 
 See that repo for more info.
 
 Each merge to the `main` branch triggers the E2E test suite, which run against
 the application [deployed to Heroku][]
 
-
 ## Deployment
 
-The application is [deployed to Heroku][] on each merge to `main` by way of a [GitHub
-Action][].
+The application is [deployed to Heroku][] on each merge to `main` by way of a
+[GitHub Action][].
 
-
-[`dxw/dfsseta-apply-for-landing-e2e`]:
-https://github.com/dxw/dfsseta-apply-for-landing-e2e
-
-[GitHub Action]:
-https://github.com/dxw/dfsseta-apply-for-landing-ruby/blob/main/.github/workflows/heroku-deployment.yml
-
-[deployed to Heroku]:
-https://apply-for-landing-ruby-4492c2b72668.herokuapp.com/
-
-### Environment variables 
+### Environment variables
 
 The following environment variables must be set on Heroku;
 
-- `HOSTNAME`: currently `apply-for-landing-ruby-4492c2b72668.herokuapp.com`
-  (the "Web URL" is shown with `heroku info`)
+- `HOSTNAME`: currently `apply-for-landing-ruby-4492c2b72668.herokuapp.com` (the
+  "Web URL" is shown with `heroku info`)
+
+[`dxw/dfsseta-apply-for-landing-e2e`]:
+  https://github.com/dxw/dfsseta-apply-for-landing-e2e
+[GitHub Action]:
+  https://github.com/dxw/dfsseta-apply-for-landing-ruby/blob/main/.github/workflows/heroku-deployment.yml
+[deployed to Heroku]: https://apply-for-landing-ruby-4492c2b72668.herokuapp.com/

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,7 @@ task :rswag_api_tests_with_docs do
          "--pattern  'spec/api/**/*_spec.rb' " \
          "--format Rswag::Specs::SwaggerFormatter " \
          "--order defined"
+
+  # Format the generated API spec with our linter
+  system "npx prettier --write 'swagger/**/*'"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,14 @@ require_relative "config/application"
 Rails.application.load_tasks
 
 desc "Run all the tests"
-task default: %i[spec standard]
+task default: %i[spec rswag_api_tests_with_docs standard]
+
+desc "Run Rswag API test with auto documentation"
+task :rswag_api_tests_with_docs do
+  # run the api specs with the Rswag formatter which creates
+  # our OpenAPI spec
+  system "bundle exec rspec " \
+         "--pattern  'spec/api/**/*_spec.rb' " \
+         "--format Rswag::Specs::SwaggerFormatter " \
+         "--order defined"
+end

--- a/app/controllers/api/landing_applications_controller.rb
+++ b/app/controllers/api/landing_applications_controller.rb
@@ -1,5 +1,7 @@
 class Api::LandingApplicationsController < ApplicationController
   def index
-    render json: {}
+    render json: LandingApplication.includes(:destination).map { |la|
+      LandingApplicationEntity.new(la).represent
+    }
   end
 end

--- a/app/entities/landing_application_entity.rb
+++ b/app/entities/landing_application_entity.rb
@@ -1,0 +1,4 @@
+class LandingApplicationEntity
+  def initialize(landing_application)
+  end
+end

--- a/app/entities/landing_application_entity.rb
+++ b/app/entities/landing_application_entity.rb
@@ -1,4 +1,22 @@
 class LandingApplicationEntity
   def initialize(landing_application)
+    @obj = landing_application
+  end
+
+  def represent
+    {
+      application_id: @obj.id,
+      pilot: {
+        name: @obj.pilot_name,
+        email: @obj.pilot_email,
+        licence_id: @obj.pilot_licence_id
+      },
+      permit_issued_at: @obj.application_decision_made_at.try(:iso8601, 0),
+      permit_id: @obj.permit_id,
+      destination: @obj.destination.name,
+      landing_date: @obj.landing_date.try(:iso8601),
+      departure_date: @obj.departure_date.try(:iso8601),
+      spacecraft_registration_id: @obj.spacecraft_registration_id
+    }
   end
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -7,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+  c.openapi_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/script/all/test
+++ b/script/all/test
@@ -56,6 +56,9 @@ else
   echo "==> Running the tests..."
   bundle exec rspec
 
+  echo "==> Running the RSwag API tests with auto-documentation..."
+  bundle exec rake rswag_api_tests_with_docs RAILS_ENV=test
+
   echo "==> Running Brakeman..."
   bundle exec brakeman -o /dev/stdout
 fi

--- a/spec/api/landing_applications_spec.rb
+++ b/spec/api/landing_applications_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe "API: landing-applications", type: :request do
         produces "application/json"
 
         response "200", "success" do
+          after do |example|
+            content = example.metadata[:response][:content] || {}
+            example_spec = {
+              "application/json" => {
+                examples: {
+                  test_example: {
+                    value: JSON.parse(response.body, symbolize_names: true)
+                  }
+                }
+              }
+            }
+            example.metadata[:response][:content] = content.deep_merge(example_spec)
+          end
+
           run_test! do |response|
             data = JSON.parse(response.body)
             expected_data = JSON.parse(expected_json_representation)

--- a/spec/api/landing_applications_spec.rb
+++ b/spec/api/landing_applications_spec.rb
@@ -2,6 +2,46 @@ require "swagger_helper"
 
 RSpec.describe "API: landing-applications", type: :request do
   describe "GET /landing-applications endpoint" do
+    let(:decision_timestamp) { Time.current + 1.week }
+    let(:landing_date) { Date.today + 1.month }
+    let(:departure_date) { Date.today + 1.month + 1.week }
+
+    before do
+      FactoryBot.create(:landing_application, {
+        id: "f5f81284-e377-4017-aab1-1efac2119a2c",
+        destination: FactoryBot.create(:landable_body, name: "Planet X"),
+        pilot_name: "Fred Smith",
+        pilot_email: "fred@example.com",
+        pilot_licence_id: "1233ABC00123",
+        spacecraft_registration_id: "ABC123A",
+        landing_date: landing_date,
+        departure_date: departure_date,
+        permit_id: "LP-3522-HNWD",
+        application_decision_made_at: decision_timestamp
+      })
+    end
+
+    let(:expected_json_representation) do
+      <<~JSON
+        [
+          {
+          "permit_id": "LP-3522-HNWD",
+          "permit_issued_at": "#{decision_timestamp.iso8601(0)}",
+          "application_id": "f5f81284-e377-4017-aab1-1efac2119a2c",
+          "destination": "Planet X",
+          "pilot": {
+            "email": "fred@example.com",
+            "name": "Fred Smith",
+            "licence_id": "1233ABC00123"
+          },
+          "spacecraft_registration_id": "ABC123A",
+          "landing_date": "#{landing_date.iso8601}",
+          "departure_date": "#{departure_date.iso8601}"
+          }
+        ]
+      JSON
+    end
+
     path "/api/landing-applications" do
       get "Retrieves a list of landing applications" do
         tags "Landing applications"
@@ -10,7 +50,9 @@ RSpec.describe "API: landing-applications", type: :request do
         response "200", "success" do
           run_test! do |response|
             data = JSON.parse(response.body)
-            expect(data).to eq({})
+            expected_data = JSON.parse(expected_json_representation)
+
+            expect(data).to eq(expected_data)
           end
         end
       end

--- a/spec/controllers/api/landing_applications_controller_spec.rb
+++ b/spec/controllers/api/landing_applications_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Api::LandingApplicationsController do
+  describe "GET :index" do
+    it "asks LandingApplicationEntity to represent each application" do
+      app_1 = double("app1")
+      app_2 = double("app2")
+
+      entity_1 = instance_double(LandingApplicationEntity, represent: double)
+      entity_2 = instance_double(LandingApplicationEntity, represent: double)
+
+      allow(LandingApplication).to receive(:includes).and_return([app_1, app_2])
+
+      allow(LandingApplicationEntity).to receive(:new).with(app_1).and_return(entity_1)
+      allow(LandingApplicationEntity).to receive(:new).with(app_2).and_return(entity_2)
+
+      get :index
+
+      expect(entity_1).to have_received(:represent)
+      expect(entity_2).to have_received(:represent)
+    end
+  end
+end

--- a/spec/entities/landing_application_entity_spec.rb
+++ b/spec/entities/landing_application_entity_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe LandingApplicationEntity do
+  let(:decision_timestamp) { Time.current + 1.week }
+  let(:landing_date) { Date.today + 1.month }
+  let(:departure_date) { Date.today + 1.month + 1.week }
+
+  let(:landing_application) do
+    LandingApplication.new(
+      id: "f5f81284-e377-4017-aab1-1efac2119a2c",
+      destination: LandableBody.new(name: "Planet X"),
+      pilot_name: "Fred Smith",
+      pilot_email: "fred@example.com",
+      pilot_licence_id: "1233ABC00123",
+      spacecraft_registration_id: "ABC123A",
+      landing_date: landing_date,
+      departure_date: departure_date,
+      permit_id: "LP-3522-HNWD",
+      application_decision_made_at: decision_timestamp
+    )
+  end
+
+  describe "#represent" do
+    let(:representation) do
+      LandingApplicationEntity.new(landing_application).represent
+    end
+
+    it "presents the id as 'application_id'" do
+      expect(representation.fetch(:application_id))
+        .to eq("f5f81284-e377-4017-aab1-1efac2119a2c")
+    end
+
+    it "presents the permit_id" do
+      expect(representation.fetch(:permit_id)).to eq("LP-3522-HNWD")
+    end
+
+    it "presents the pilot's properties in their own nested object" do
+      expect(representation.fetch(:pilot))
+        .to eq({
+          email: "fred@example.com",
+          name: "Fred Smith",
+          licence_id: "1233ABC00123"
+        })
+    end
+
+    it "presents the #application_decision_made_at as 'permit_issued_at'" do
+      expect(representation.fetch(:permit_issued_at))
+        .to eq(decision_timestamp.iso8601(0))
+    end
+
+    it "presents the destination name" do
+      expect(representation.fetch(:destination)).to eq("Planet X")
+    end
+
+    it "presents the spacecraft_registration_id" do
+      expect(representation.fetch(:spacecraft_registration_id)).to eq("ABC123A")
+    end
+
+    it "presents the landing and departure dates" do
+      aggregate_failures do
+        expect(representation.fetch(:landing_date)).to eq(landing_date.iso8601)
+        expect(representation.fetch(:departure_date)).to eq(departure_date.iso8601)
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -8,32 +8,32 @@ paths:
     get:
       summary: Retrieves a list of landing applications
       tags:
-      - Landing applications
+        - Landing applications
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:
               examples:
                 test_example:
                   value:
-                  - application_id: f5f81284-e377-4017-aab1-1efac2119a2c
-                    destination: Planet X
-                    pilot:
-                      name: Fred Smith
-                      email: fred@example.com
-                      licence_id: 1233ABC00123
-                    permit_issued_at: '2024-09-17T15:38:09Z'
-                    permit_id: LP-3522-HNWD
-                    spacecraft_registration_id: ABC123A
-                    landing_date: '2024-10-10'
-                    departure_date: '2024-10-17'
+                    - application_id: f5f81284-e377-4017-aab1-1efac2119a2c
+                      destination: Planet X
+                      pilot:
+                        name: Fred Smith
+                        email: fred@example.com
+                        licence_id: 1233ABC00123
+                      permit_issued_at: "2024-09-18T07:53:21Z"
+                      permit_id: LP-3522-HNWD
+                      spacecraft_registration_id: ABC123A
+                      landing_date: "2024-10-11"
+                      departure_date: "2024-10-18"
 servers:
-- url: https://{defaultHost}
-  variables:
-    defaultHost:
-      default: localhost
-- url: http://{defaultHost}
-  variables:
-    defaultHost:
-      default: localhost:3000
+  - url: https://{defaultHost}
+    variables:
+      defaultHost:
+        default: localhost
+  - url: http://{defaultHost}
+    variables:
+      defaultHost:
+        default: localhost:3000

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -12,6 +12,22 @@ paths:
       responses:
         '200':
           description: success
+          content:
+            application/json:
+              examples:
+                test_example:
+                  value:
+                  - application_id: f5f81284-e377-4017-aab1-1efac2119a2c
+                    destination: Planet X
+                    pilot:
+                      name: Fred Smith
+                      email: fred@example.com
+                      licence_id: 1233ABC00123
+                    permit_issued_at: '2024-09-17T15:38:09Z'
+                    permit_id: LP-3522-HNWD
+                    spacecraft_registration_id: ABC123A
+                    landing_date: '2024-10-10'
+                    departure_date: '2024-10-17'
 servers:
 - url: https://{defaultHost}
   variables:


### PR DESCRIPTION
In this PR we:

- introduce a "presenter" class `LandingApplicationEntity` with responsibility for creating a representation of a `LandingApplication` to be exposed in JSON at the `/api/landing-applications` endpoint

- use Rswag's `example` method to set the OpenAPI spec's example response from our test fixture

- make some changes to our testing toolchain to ensure that the OpenAPI spec is updated and formatted reliably

### Example added to OpenAPI spec

![openapi_spec_with_example](https://github.com/user-attachments/assets/49de4cdd-47e0-4764-a4ef-1978a04ca9e7)

