### PR TITLE
Support development with VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ tmp/
 
 ## Personal developer config
 .pryrc
+.vscode

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ group :development do
   gem "listen", ">= 3.0.5", "< 3.10"
   gem "rails_layout"
   gem "web-console", ">= 3.3.0"
+  gem "htmlbeautifier"
+  gem "solargraph"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,8 +76,10 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
+    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    benchmark (0.3.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -139,6 +141,7 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     drb (2.2.1)
+    e2mmap (0.1.0)
     erubi (1.13.0)
     execjs (2.9.1)
     factory_bot (6.4.5)
@@ -163,12 +166,14 @@ GEM
     high_voltage (3.1.2)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
+    htmlbeautifier (1.4.3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.6.0)
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -181,6 +186,10 @@ GEM
     json (2.7.2)
     json-schema (4.3.1)
       addressable (>= 2.8)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -294,6 +303,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -304,6 +314,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.3.6)
       strscan
     rollbar (3.6.0)
@@ -380,6 +392,22 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    solargraph (0.50.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -433,6 +461,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -460,6 +489,7 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   high_voltage
+  htmlbeautifier
   jbuilder (~> 2.11)
   jquery-rails
   jsbundling-rails
@@ -482,6 +512,7 @@ DEPENDENCIES
   seed-fu
   selenium-webdriver
   simplecov
+  solargraph
   standard
   terser
   timecop


### PR DESCRIPTION
In this PR we provide some support for developing with VSCode:

Add gems to aid dev with VSCode

- solargraph language server: the [solargraph gem][] works
  with the [VSCode Solargraph extension][] to provide a lot of
  functionality for exploring the code and language

- the [htmlbeautifier gem][] is required by VS Code's
  [ERB Formatter/Beautify extension][]

[solargraph gem]:
https://github.com/castwide/solargraph

[VSCode Solargraph extension]:
https://marketplace.visualstudio.com/items?itemName=castwide.solargraph

[htmlbeautifier gem]:
https://github.com/threedaymonk/htmlbeautifier

[ERB Formatter/Beautify extension]:
https://marketplace.visualstudio.com/items?itemName=aliariff.vscode-erb-beautify