### PR TITLE
Remove docker caching from CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,26 +18,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - id: cache-docker
-        uses: actions/cache@v3
-        with:
-          path: /tmp/docker-save
-          key:
-            docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
-            'package-lock.json') }}
-
-      - if: steps.cache-docker.outputs.cache-hit == 'true'
-        name: Load cached Docker image
-        run: docker load -i /tmp/docker-save/snapshot.tar || true
-
       - name: Build
         run: script/ci/cibuild
 
       - name: Test
         run: script/ci/test
-
-      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
-        name: Prepare Docker cache
-        run:
-          mkdir -p /tmp/docker-save && docker save app_test:latest -o
-          /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save


### PR DESCRIPTION
Similar to in our Rails and Nest templates, this seems to slow CI down, so it's probably quicker not to use a cache

The branch this commit is on was originally branched off renovate/node-20.x for the purpose of comparison. CI had been run on that branch multiple times, but the "Run actions/cache@v3" step couldn't find a matching cache for whatever reason. It spends almost three minutes building that cache at the end of each test CI job run. The first run of this branch was - expectedly - about three minutes quicker than the reference branch (6m13s vs 3m25s)

https://github.com/dxw/rails-template/commit/1f78864444f22c4ae4372a7a584fda1e55dba88f
https://github.com/dxw/nest-template/commit/75890e11aad58773fdd0330b2796391fba5bfac7