### PR TITLE
Remove version from Docker compose files

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   test:
     build:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   test:
     build:


### PR DESCRIPTION
This is obsolete: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-optional