### PR TITLE
Generate and record a permit ID when application is approved

### DIFF
--- a/app/controllers/officer/decisions_controller.rb
+++ b/app/controllers/officer/decisions_controller.rb
@@ -4,15 +4,10 @@ class Officer::DecisionsController < ApplicationController
   end
 
   def create
-    application = LandingApplication.find(params[:landing_application_id])
     @application_decision = AssessmentDecisionForm.new(application_decision: params.dig(:assessment_decision_form, "application_decision"))
 
-    application.application_decision = @application_decision.application_decision
-
     if @application_decision.valid?
-      application.application_decision_made_at = Time.current
-      application.assessor = current_user
-      application.save
+      DecisionsService.new(@application_decision.application_decision, params[:landing_application_id], current_user)
       redirect_to(officer_landing_applications_path)
     else
       render :new

--- a/app/services/decisions_service.rb
+++ b/app/services/decisions_service.rb
@@ -1,0 +1,9 @@
+class DecisionsService
+  def self.new(application_decision, application_id, assessor)
+    application = LandingApplication.find(application_id)
+    application.application_decision = application_decision
+    application.application_decision_made_at = Time.current
+    application.assessor = assessor
+    application.save
+  end
+end

--- a/app/services/decisions_service.rb
+++ b/app/services/decisions_service.rb
@@ -4,6 +4,9 @@ class DecisionsService
     application.application_decision = application_decision
     application.application_decision_made_at = Time.current
     application.assessor = assessor
+    if application_decision == "approved"
+      application.permit_id = SecureRandom.uuid
+    end
     application.save
   end
 end


### PR DESCRIPTION
Creates a new decisions service to handle updates to the landing application when an assessor makes a decision. This service also generates and saves a permit ID to the application when the decision is to approve.