### PR TITLE
Install Heroku CLI as part of deployment action

### DIFF
--- a/.github/workflows/heroku-deployment.yml
+++ b/.github/workflows/heroku-deployment.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
       - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.13.15
         with:


### PR DESCRIPTION
Deployments have been failing for a while e.g. [this one](https://github.com/dxw/dfsseta-apply-for-landing-ruby/actions/runs/14313929923), as the new version of `ubuntu-latest` doesn't come with `heroku-cli` installed, as per [this issue](https://github.com/AkhileshNS/heroku-deploy/issues/188), so here we install it manually as directed in the README [here](https://github.com/AkhileshNS/heroku-deploy?tab=readme-ov-file#getting-started).