### PR TITLE
Cast `application_decision` integers in migration

### DIFF
--- a/db/migrate/20240913140449_add_decision_enum_to_landing_application.rb
+++ b/db/migrate/20240913140449_add_decision_enum_to_landing_application.rb
@@ -1,5 +1,5 @@
 class AddDecisionEnumToLandingApplication < ActiveRecord::Migration[7.2]
   def change
-    change_column :landing_applications, :application_decision, :integer
+    change_column :landing_applications, :application_decision, "integer USING CAST(application_decision AS integer)"
   end
 end


### PR DESCRIPTION
This was failing on deployment but not on CI or locally, likely due to there being old data in Production. Here's the error we were seeing:

```
PG::DatatypeMismatch: ERROR:  column "application_decision" cannot be cast automatically to type integer
HINT:  You might need to specify "USING application_decision::integer".
```

This appears to be the way to cast types to integers that can't be done automatically according to the accepted answer in [this Stack Overflow thread](https://stackoverflow.com/questions/44131984/activerecord-column-cannot-be-cast-automatically-to-type-numeric)

Ideally we'd not edit an existing migration here, but as this is not applying on Production we don't really have much choice!